### PR TITLE
Fix memory leak in receive path

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
@@ -175,15 +175,9 @@ public final class ReceiveLinkHandler extends BaseLinkHandler
             msg.decode(buffer, 0, read);
             
             messages.add(msg);
+            delivery.settle();
             
-            if (receiveLink.advance())
-            {
-            	delivery = receiveLink.current();
-            }
-            else
-            {    
-            	break;
-            }
+            delivery = receiveLink.current();
         }
         
         if (messages != null && messages.size() > 0)


### PR DESCRIPTION
settle the messages as soon as they are handed off to receiver