### PR TITLE
Handle onReactorFinal event & exceptions (inc. npe)

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -23,7 +23,7 @@ public class EventHubClient extends ClientEntity
 	
 	private EventHubClient(ConnectionStringBuilder connectionString) throws IOException, IllegalEntityException
 	{
-		super(UUID.randomUUID().toString());
+		super(StringUtil.getRandomString());
 		this.eventHubName = connectionString.getEntityPath();
 	}
 	
@@ -86,7 +86,7 @@ public class EventHubClient extends ClientEntity
 	
 	CompletableFuture<Void> createInternalSender()
 	{
-		return MessageSender.Create(this.underlyingFactory, UUID.randomUUID().toString(), this.eventHubName)
+		return MessageSender.Create(this.underlyingFactory, StringUtil.getRandomString(), this.eventHubName)
 				.thenAcceptAsync(new Consumer<MessageSender>()
 				{
 					public void accept(MessageSender a) { EventHubClient.this.sender = a;}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubSender.java
@@ -1,6 +1,5 @@
 package com.microsoft.azure.eventhubs;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
 
@@ -40,7 +39,7 @@ public final class EventHubSender
 	
 	private CompletableFuture<Void> createInternalSender() throws ServiceBusException
 	{
-		return MessageSender.Create(this.factory, UUID.randomUUID().toString(), 
+		return MessageSender.Create(this.factory, StringUtil.getRandomString(), 
 				String.format("%s/Partitions/%s", this.eventHubName, this.partitionId))
 				.thenAcceptAsync(new Consumer<MessageSender>()
 				{

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -77,7 +77,7 @@ public final class PartitionReceiver
 	
 	private CompletableFuture<Void> createInternalReceiver() throws ServiceBusException
 	{
-		return MessageReceiver.create(this.underlyingFactory, UUID.randomUUID().toString(), 
+		return MessageReceiver.create(this.underlyingFactory, StringUtil.getRandomString(), 
 				String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId), 
 				this.startingOffset, this.offsetInclusive, this.startingDateTime, PartitionReceiver.DefaultPrefetchCount, this.epoch, this.isEpochReceiver)
 				.thenAcceptAsync(new Consumer<MessageReceiver>()

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -32,7 +32,5 @@ public final class ClientConstants
 	
 	public final static String ServiceBusClientTrace = "servicebus.trace";
 	
-	public final static int AmqpLinkDetachTimeoutInMin = 8;
-	
 	public final static boolean DefaultIsTransient = true;
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/StringUtil.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/StringUtil.java
@@ -1,5 +1,7 @@
 package com.microsoft.azure.servicebus;
 
+import java.util.UUID;
+
 public final class StringUtil
 {
 	public final static String EMPTY = "";
@@ -23,5 +25,10 @@ public final class StringUtil
 		}
 		
 		return true;
+	}
+	
+	public static String getRandomString()
+	{
+		return UUID.randomUUID().toString().substring(0, 6);
 	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
@@ -107,6 +107,12 @@ public class SendLinkHandler extends BaseLinkHandler
         }
 	}
 	
+	public void processOnClose(Link link, Exception exception)
+	{
+		link.close();
+		this.msgSender.onError(exception);
+	}
+	
 	@Override
 	public void onLinkRemoteDetach(Event event)
 	{


### PR DESCRIPTION
Register links for Connection/Reactor Errors as soon as they are created (and before they are opened)Recreated Link Names should be different from old names.
Simplify Receiver ping logic - send flow(1)
Shorten linkNames.
