### PR TITLE
Start JavaDocs, depublic certain methods

### DIFF
--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -3,7 +3,6 @@ package com.microsoft.azure.eventprocessorhost;
 import java.util.concurrent.Future;
 
 // WILL NORMALLY BE IMPLEMENTED ON THE SAME CLASS AS ILeaseManager
-// Requires IManagerBase also
 public interface ICheckpointManager
 {
     public Future<Boolean> checkpointStoreExists();

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
@@ -3,11 +3,48 @@ package com.microsoft.azure.eventprocessorhost;
 import com.microsoft.azure.eventhubs.EventData;
 
 
+/**
+ * Interface that must be implemented by event processor classes.
+ *
+ * <p>
+ * Any given instance of an event processor class will only process events from one partition
+ * of one Event Hub. A PartitionContext is provided with each call to the event processor because
+ * some parameters could change, but it will always be the same partition.
+ * <p>
+ * Although EventProcessorHost is multithreaded, calls to a given instance of an event processor
+ * class are serialized. onOpen() is called first, then onEvents() will be called zero or more
+ * times. When the event processor needs to be shut down, whether because there was a failure
+ * somewhere, or the lease for the partition has been lost, or because the entire processor host
+ * is being shut down, onClose() is called after the last onEvents() call returns.
+ *
+ */
 public interface IEventProcessor
 {
+	/**
+	 * Called by processor host to initialize the event processor.
+	 *  
+	 * @param context	Information about the partition that this event processor will process events from.
+	 * @throws Exception
+	 */
     public void onOpen(PartitionContext context) throws Exception;
 
+    /**
+     * Called by processor host to indicate that the event processor is being stopped.
+     * 
+     * @param context	Information about the partition.
+     * @param reason	Reason why the event processor is being stopped.
+     * @throws Exception
+     */
     public void onClose(PartitionContext context, CloseReason reason) throws Exception;
 
+    /**
+     * Called by the processor host when a batch of events has arrived.
+     * 
+     * This is where the real work of the event processor is done.
+     * 
+     * @param context	Information about the partition.
+     * @param messages	The events to be processed.
+     * @throws Exception
+     */
     public void onEvents(PartitionContext context, Iterable<EventData> messages) throws Exception;
 }

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessorFactory.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessorFactory.java
@@ -1,9 +1,12 @@
 package com.microsoft.azure.eventprocessorhost;
 
 
+/**
+ * Interface that must be implemented by an event processor factory class.
+ *
+ * @param <T>	The type of event processor objects produced by this factory, which must implement IEventProcessor
+ */
 public interface IEventProcessorFactory<T extends IEventProcessor>
 {
-    public void setEventProcessorClass(Class<T> eventProcessorClass);
-
     public T createEventProcessor(PartitionContext context) throws Exception;
 }

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 
-public class PartitionManager implements Runnable
+class PartitionManager implements Runnable
 {
     private EventProcessorHost host;
     private Pump pump;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 
-public class Pump
+class Pump
 {
     private EventProcessorHost host;
 


### PR DESCRIPTION
1) Start JavaDocs
2) Remove "public" on methods that don't need to be public.
3) Remove obsolete comment on ICheckpointManager
4) Remove setEventProcessorClass() on IEventProcessorFactory. That method is only needed on DefaultEventProcessorFactory.