### PR TITLE
Bulk change pull

### DIFF
--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Checkpoint.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Checkpoint.java
@@ -18,6 +18,13 @@ public class Checkpoint
 		this.partitionId = partitionId;
 	}
 	
+	public Checkpoint(String partitionId, String offset, long sequenceNumber)
+	{
+		this.partitionId = partitionId;
+		this.offset = offset;
+		this.sequenceNumber = sequenceNumber;
+	}
+	
 	public Checkpoint(Checkpoint source)
 	{
 		this.partitionId = source.partitionId;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/CheckpointDispatcher.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/CheckpointDispatcher.java
@@ -1,0 +1,133 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+
+public class CheckpointDispatcher
+{
+	private EventProcessorHost host;
+	private ICheckpointManager checkpointManager;
+	
+	private LinkedList<Checkpoint> workQueue;
+	private boolean keepGoing = true;
+	private Future<Void> workThread = null;
+	
+	public CheckpointDispatcher(EventProcessorHost host)
+	{
+		this.host = host;
+		this.checkpointManager = host.getCheckpointManager();
+		
+		this.workQueue = new LinkedList<Checkpoint>();
+	}
+	
+	public synchronized void startCheckpointDispatcher()
+	{
+		if ((this.workThread == null) || this.workThread.isDone())
+		{
+			this.keepGoing = true;
+			this.workThread = EventProcessorHost.getExecutorService().submit(() -> runWorkThread());
+		}
+	}
+	
+	public void stopCheckpointDispatcher()
+	{
+		this.keepGoing = false;
+		try
+		{
+			this.workThread.get();
+		}
+		catch (InterruptedException | ExecutionException e)
+		{
+			// Worker thread failed on shutdown. Nothing to do about it except log.
+			this.host.logWithHost(Level.WARNING, "Checkpoint dispatcher thread failed on shutdown", e);
+		}
+	}
+	
+	public void enqueueCheckpoint(Checkpoint checkpoint)
+	{
+		synchronized (this.workQueue)
+		{
+			this.workQueue.addFirst(checkpoint);
+		}
+		// The work thread shuts down if it has nothing to do, so when new work comes in make sure that it
+		// is running. startCheckpointDispatcher() is itempotent and will not start a second thread if one
+		// is already running, so we can just call it blindly here.
+		startCheckpointDispatcher();
+	}
+	
+	private Void runWorkThread()
+	{
+		String shutdownReason = "requested shutdown";
+		
+		this.host.logWithHost(Level.INFO, "Checkpoint dispatcher starting");
+		
+		while (this.keepGoing)
+		{
+			while ((this.workQueue.size() > 0) && this.keepGoing)
+			{
+				Checkpoint workToDo = null;
+				synchronized (this.workQueue)
+				{
+					workToDo = this.workQueue.removeLast();
+				}
+				
+		    	this.host.logWithHostAndPartition(Level.FINE, workToDo.getPartitionId(), "CheckPoint dispatcher processing: " +
+		    			workToDo.getOffset() + "//" + workToDo.getSequenceNumber());
+				
+				try
+				{
+					// Because there is only one checkpoint updater thread, and it processes checkpoints in order,
+					// the offset should never go backwards. If it tries to, we skip the update, but can't do anything
+					// except log a trace.
+			    	Checkpoint inStoreCheckpoint = this.checkpointManager.getCheckpoint(workToDo.getPartitionId()).get();
+			    	if (workToDo.getSequenceNumber() >= inStoreCheckpoint.getSequenceNumber())
+			    	{
+				    	inStoreCheckpoint.setOffset(workToDo.getOffset());
+				    	inStoreCheckpoint.setSequenceNumber(workToDo.getSequenceNumber());
+				        this.checkpointManager.updateCheckpoint(inStoreCheckpoint).get();
+			    	}
+			    	else
+			    	{
+			    		this.host.logWithHostAndPartition(Level.SEVERE, workToDo.getPartitionId(),
+			    			"Abandoning out of date checkpoint " + workToDo.getOffset() + "//" + workToDo.getSequenceNumber() +
+			    			" because store is at " + inStoreCheckpoint.getOffset() + "//" + inStoreCheckpoint.getSequenceNumber());
+			    	}
+				}
+				catch (ExecutionException | InterruptedException e)
+				{
+					this.host.logWithHost(Level.SEVERE, "Exception in checkpoint dispatcher", e);
+					shutdownReason = "error";
+					this.keepGoing = false;
+					break;
+				}
+			}
+			
+			if (this.keepGoing)
+			{
+				// We can only get here if queue size is 0. Sleep a few seconds to see if more work
+				// comes in, so we don't flap the thread.
+				
+				try
+				{
+					Thread.sleep(2000);
+				}
+				catch (InterruptedException e)
+				{
+					shutdownReason = "interrupted";
+					break;
+				}
+				
+				if (this.workQueue.size() <= 0)
+				{
+					shutdownReason = "out of work";
+					break;
+				}
+			}
+		}
+		
+		this.host.logWithHost(Level.INFO, "Checkpoint dispatcher shutting down: " + shutdownReason);
+		return null;
+	}
+}

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -78,7 +78,7 @@ class EventHubPartitionPump extends PartitionPump
 		this.eventHubClient = (EventHubClient) this.internalOperationFuture.get();
 		this.internalOperationFuture = null;
 		
-    	String startingOffset = this.partitionContext.getStartingOffset();
+    	String startingOffset = this.partitionContext.getInitialOffset();
     	long epoch = this.lease.getEpoch();
     	this.host.logWithHostAndPartition(Level.FINE, this.partitionContext, "Opening EH receiver with epoch " + epoch + " at offset " + startingOffset);
 		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(), startingOffset, epoch);

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -84,6 +84,7 @@ class EventHubPartitionPump extends PartitionPump
 		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(), startingOffset, epoch);
 		this.lease.setEpoch(epoch);
 		this.partitionReceiver = (PartitionReceiver) this.internalOperationFuture.get();
+		this.partitionReceiver.setPrefetchCount(this.host.getEventProcessorOptions().getPrefetchCount());
 		this.internalOperationFuture = null;
 		
         this.host.logWithHostAndPartition(Level.FINE, this.partitionContext, "EH client and receiver creation finished");

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -171,6 +171,7 @@ class EventHubPartitionPump extends PartitionPump
 				{
 					EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error continued", (Exception)error);
 				}
+				EventHubPartitionPump.this.onError(error);
 			}
 			EventHubPartitionPump.this.pumpStatus = PartitionPumpStatus.PP_ERRORED;
 		}

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -158,10 +158,18 @@ class EventHubPartitionPump extends PartitionPump
 			{
 				error = new Throwable("No error info supplied by EventHub client");
 			}
-			EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error: " + error.toString());
-			if (error instanceof Exception)
+			if (error instanceof ReceiverDisconnectedException)
 			{
-				EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error continued", (Exception)error);
+				EventHubPartitionPump.this.host.logWithHostAndPartition(Level.WARNING, EventHubPartitionPump.this.partitionContext,
+						"EventHub client disconnected, probably another host took the partition");
+			}
+			else
+			{
+				EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error: " + error.toString());
+				if (error instanceof Exception)
+				{
+					EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error continued", (Exception)error);
+				}
 			}
 			EventHubPartitionPump.this.pumpStatus = PartitionPumpStatus.PP_ERRORED;
 		}

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -28,6 +28,7 @@ public final class EventProcessorHost
     private ILeaseManager leaseManager;
     private boolean initializeLeaseManager = false; 
     private PartitionManager partitionManager;
+    private CheckpointDispatcher checkpointDispatcher;
     private Future<?> partitionManagerFuture = null;
     private IEventProcessorFactory<?> processorFactory;
     private EventProcessorOptions processorOptions;
@@ -151,6 +152,7 @@ public final class EventProcessorHost
                 sharedAccessKeyName, sharedAccessKey).toString();
 
         this.partitionManager = new PartitionManager(this);
+        this.checkpointDispatcher = new CheckpointDispatcher(this);
         
         logWithHost(Level.INFO, "New EventProcessorHost created");
     }
@@ -197,6 +199,7 @@ public final class EventProcessorHost
     ICheckpointManager getCheckpointManager() { return this.checkpointManager; }
     ILeaseManager getLeaseManager() { return this.leaseManager; }
     PartitionManager getPartitionManager() { return this.partitionManager; }
+    CheckpointDispatcher getCheckpointDispatcher() { return this.checkpointDispatcher; }
     IEventProcessorFactory<?> getProcessorFactory() { return this.processorFactory; }
     String getEventHubPath() { return this.eventHubPath; }
     String getConsumerGroupName() { return this.consumerGroupName; }
@@ -287,6 +290,8 @@ public final class EventProcessorHost
         this.processorFactory = factory;
         this.processorOptions = processorOptions;
         this.partitionManagerFuture = EventProcessorHost.executorService.submit(this.partitionManager);
+        // Don't need to start the checkpointDispatcher here -- it auto-starts when work is added to its queue.
+        
         return this.partitionManagerFuture;
     }
 

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -6,7 +6,6 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import com.microsoft.azure.servicebus.ConnectionStringBuilder;
-import com.microsoft.azure.servicebus.RetryPolicy;
 import com.microsoft.azure.storage.StorageException;
 
 import java.net.URISyntaxException;
@@ -364,8 +363,8 @@ public final class EventProcessorHost
     
     void log(Level logLevel, String logMessage)
     {
-  		EventProcessorHost.TRACE_LOGGER.log(logLevel, logMessage);
-    	//System.out.println(logLevel.toString() + ": " + logMessage);
+  		//EventProcessorHost.TRACE_LOGGER.log(logLevel, logMessage);
+    	System.out.println(logLevel.toString() + ": " + logMessage);
     }
     
     void logWithHost(Level logLevel, String logMessage)

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import com.microsoft.azure.servicebus.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.RetryPolicy;
 import com.microsoft.azure.storage.StorageException;
 
 import java.net.URISyntaxException;
@@ -21,6 +22,8 @@ public final class EventProcessorHost
     private final String hostName;
     private final String namespaceName;
     private final String eventHubPath;
+    private final String sharedAccessKeyName;
+    private final String sharedAccessKey;
     private final String consumerGroupName;
     private String eventHubConnectionString;
 
@@ -137,6 +140,8 @@ public final class EventProcessorHost
         this.hostName = hostName;
         this.namespaceName = namespaceName;
         this.eventHubPath = eventHubPath;
+        this.sharedAccessKeyName = sharedAccessKeyName;
+        this.sharedAccessKey = sharedAccessKey;
         this.consumerGroupName = consumerGroupName;
         this.checkpointManager = checkpointManager;
         this.leaseManager = leaseManager;
@@ -147,9 +152,6 @@ public final class EventProcessorHost
 	        	EventProcessorHost.executorRefCount++;
 	        }
         }
-
-        this.eventHubConnectionString = new ConnectionStringBuilder(this.namespaceName, this.eventHubPath,
-                sharedAccessKeyName, sharedAccessKey).toString();
 
         this.partitionManager = new PartitionManager(this);
         this.checkpointDispatcher = new CheckpointDispatcher(this);
@@ -273,6 +275,10 @@ public final class EventProcessorHost
      */
     public Future<?> registerEventProcessorFactory(IEventProcessorFactory<?> factory, EventProcessorOptions processorOptions)
     {
+    	// This is where we would set the timeout if javaClient supported it.
+        this.eventHubConnectionString = new ConnectionStringBuilder(this.namespaceName, this.eventHubPath,
+                this.sharedAccessKeyName, this.sharedAccessKey /*, processorOptions.getReceiveTimeOut(), RetryPolicy.getDefault()*/).toString();
+
         if (this.initializeLeaseManager)
         {
             try

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -43,14 +43,6 @@ public final class EventProcessorHost
     public final static String EVENTPROCESSORHOST_TRACE = "eventprocessorhost.trace";
 	private static final Logger TRACE_LOGGER = Logger.getLogger(EventProcessorHost.EVENTPROCESSORHOST_TRACE);
     
-    
-    // DUMMY STARTS
-    public static void setDummyPartitionCount(int count)
-    {
-    	PartitionManager.dummyPartitionCount = count;
-    	TRACE_LOGGER.setLevel(Level.FINEST);
-    }
-    // DUMMY ENDS
 
     /**
      * Create a new host to process events from an Event Hub.

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.time.Duration;
+import java.util.function.Function;
 
 public final class EventProcessorOptions
 {
@@ -13,6 +14,7 @@ public final class EventProcessorOptions
     private int maxBatchSize = 10;
     private int prefetchCount = 300;
     private Duration receiveTimeOut = Duration.ofMinutes(1);
+    private Function<String, String> initialOffsetProvider = null;
 
     public static EventProcessorOptions getDefaultOptions()
     {
@@ -64,9 +66,15 @@ public final class EventProcessorOptions
         this.prefetchCount = prefetchCount;
     }
 
-    //
-    // TODO Initial offset provider goes here.
-    //
+    public Function<String, String> getInitialOffsetProvider()
+    {
+    	return this.initialOffsetProvider;
+    }
+    
+    public void setInitialOffsetProvider(Function<String, String> initialOffsetProvider)
+    {
+    	this.initialOffsetProvider = initialOffsetProvider;
+    }
     
     public Boolean getInvokeProcessorAfterReceiveTimeout()
     {

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -24,7 +24,8 @@ public final class EventProcessorOptions
     }
     
     //
-    // TODO User exception handler goes here.
+    // The .NET library sets the user error handler here.
+    // This version has the user error handler in IEventProcessor.
     //
 
     public int getMaxBatchSize()

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -45,10 +45,13 @@ public final class EventProcessorOptions
         return this.receiveTimeOut;
     }
 
+    /*
+     * JavaClient has a way to set the timeout but it is not exposed right now.
     public void setReceiveTimeOut(Duration receiveTimeOut)
     {
         this.receiveTimeOut = receiveTimeOut;
     }
+    */
 
     public int getPrefetchCount()
     {

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -5,13 +5,14 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import java.time.Duration;
 
 public final class EventProcessorOptions
 {
     private Boolean invokeProcessorAfterReceiveTimeout = false;
     private int maxBatchSize = 10;
     private int prefetchCount = 300;
-    private int receiveTimeOutMilliseconds = 60000; // default to one minute
+    private Duration receiveTimeOut = Duration.ofMinutes(1);
 
     public static EventProcessorOptions getDefaultOptions()
     {
@@ -21,7 +22,48 @@ public final class EventProcessorOptions
     public EventProcessorOptions()
     {
     }
+    
+    //
+    // TODO User exception handler goes here.
+    //
 
+    public int getMaxBatchSize()
+    {
+        return this.maxBatchSize;
+    }
+
+    /*
+     * JavaClient does not have a max batch size setting for receive.
+    public void setMaxBatchSize(int maxBatchSize)
+    {
+        this.maxBatchSize = maxBatchSize;
+    }
+    */
+
+    public Duration getReceiveTimeOut()
+    {
+        return this.receiveTimeOut;
+    }
+
+    public void setReceiveTimeOut(Duration receiveTimeOut)
+    {
+        this.receiveTimeOut = receiveTimeOut;
+    }
+
+    public int getPrefetchCount()
+    {
+        return this.prefetchCount;
+    }
+
+    public void setPrefetchCount(int prefetchCount)
+    {
+        this.prefetchCount = prefetchCount;
+    }
+
+    //
+    // TODO Initial offset provider goes here.
+    //
+    
     public Boolean getInvokeProcessorAfterReceiveTimeout()
     {
         return this.invokeProcessorAfterReceiveTimeout;
@@ -37,34 +79,4 @@ public final class EventProcessorOptions
         this.invokeProcessorAfterReceiveTimeout = invokeProcessorAfterReceiveTimeout;
     }
     */
-
-    public int getMaxBatchSize()
-    {
-        return this.maxBatchSize;
-    }
-
-    public void setMaxBatchSize(int maxBatchSize)
-    {
-        this.maxBatchSize = maxBatchSize;
-    }
-
-    public int getPrefetchCount()
-    {
-        return this.prefetchCount;
-    }
-
-    public void setPrefetchCount(int prefetchCount)
-    {
-        this.prefetchCount = prefetchCount;
-    }
-
-    public int getReceiveTimeOut()
-    {
-        return this.receiveTimeOutMilliseconds;
-    }
-
-    public void setReceiveTimeOut(int receiveTimeOutMilliseconds)
-    {
-        this.receiveTimeOutMilliseconds = receiveTimeOutMilliseconds;
-    }
 }

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
@@ -52,4 +52,6 @@ public interface IEventProcessor
      * @throws Exception
      */
     public void onEvents(PartitionContext context, Iterable<EventData> messages) throws Exception;
+    
+    public void onError(PartitionContext context, Throwable error);
 }

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import com.microsoft.azure.eventhubs.PartitionReceiver;
-
 public class Lease
 {
     private String eventHubPath;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -109,7 +109,7 @@ public class PartitionContext
     public Future<Void> checkpoint(EventData event) throws InterruptedException, ExecutionException
     {
     	Checkpoint inStoreCheckpoint = this.checkpointManager.getCheckpoint(this.partitionId).get();
-    	if (this.sequenceNumber >= inStoreCheckpoint.getSequenceNumber())
+    	if (event.getSystemProperties().getSequenceNumber() >= inStoreCheckpoint.getSequenceNumber())
     	{
 	    	inStoreCheckpoint.setOffset(event.getSystemProperties().getOffset());
 	    	inStoreCheckpoint.setSequenceNumber(event.getSystemProperties().getSequenceNumber());

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -66,7 +66,7 @@ class PartitionManager implements Runnable
         	try
         	{
 	        	String contentEncoding = StandardCharsets.UTF_8.name();
-	        	ConnectionStringBuilder connectionString = new ConnectionStringBuilder(host.getEventHubConnectionString());
+	        	ConnectionStringBuilder connectionString = new ConnectionStringBuilder(this.host.getEventHubConnectionString());
 	        	URI namespaceUri = new URI("https", connectionString.getEndpoint().getHost(), null, null);
 	        	String resourcePath = String.join("/", namespaceUri.toString(), connectionString.getEntityPath());
 	        	
@@ -98,6 +98,12 @@ class PartitionManager implements Runnable
         	{
         		throw new EPHConfigurationException("Encountered error while fetching the list of EventHub PartitionIds", exception);
         	}
+            
+            this.host.logWithHost(Level.INFO, "Eventhub " + this.host.getEventHubPath() + " count of partitions: " + this.partitionIds.size());
+            for (String id : this.partitionIds)
+            {
+            	this.host.logWithHost(Level.FINE, "Found partition with id: " + id);
+            }
         }
         
         return this.partitionIds;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -8,7 +8,6 @@ package com.microsoft.azure.eventprocessorhost;
 import java.util.List;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -37,9 +36,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import com.microsoft.azure.servicebus.ConnectionStringBuilder;
-import com.microsoft.azure.servicebus.ServiceBusException;
 import com.microsoft.azure.servicebus.SharedAccessSignatureTokenProvider;
-import com.microsoft.azure.servicebus.StringUtil;
 
 
 class PartitionManager implements Runnable
@@ -50,10 +47,6 @@ class PartitionManager implements Runnable
     private List<String> partitionIds = null;
     
     private boolean keepGoing = true;
-
-    // DUMMY STARTS
-    public static int dummyPartitionCount = 4;
-    // DUMMY ENDS
 
     public PartitionManager(EventProcessorHost host)
     {

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -34,7 +34,8 @@ public abstract class PartitionPump
 		this.partitionContext.setLease(newLease);
 	}
 	
-    public void startPump()
+	// return Void so it can be called from a lambda submitted to ExecutorService
+    public Void startPump()
     {
     	this.pumpStatus = PartitionPumpStatus.PP_OPENING;
     	
@@ -65,6 +66,8 @@ public abstract class PartitionPump
         {
         	specializedStartPump();
         }
+        
+        return null;
     }
 
     public abstract void specializedStartPump();

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -137,6 +137,8 @@ public abstract class PartitionPump
         		}
         		if (last != null)
         		{
+        			this.host.logWithHostAndPartition(Level.FINE, this.partitionContext, "Updating offset in partition context with end of batch " +
+        					last.getSystemProperties().getOffset() + "//" + last.getSystemProperties().getSequenceNumber());
         			this.partitionContext.setOffsetAndSequenceNumber(last);
         		}
         	}

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -38,7 +38,7 @@ public abstract class PartitionPump
     {
     	this.pumpStatus = PartitionPumpStatus.PP_OPENING;
     	
-        this.partitionContext = new PartitionContext(this.host.getCheckpointManager(), this.lease.getPartitionId());
+        this.partitionContext = new PartitionContext(this.host, this.lease.getPartitionId());
         this.partitionContext.setEventHubPath(this.host.getEventHubPath());
         this.partitionContext.setConsumerGroupName(this.host.getConsumerGroupName());
         this.partitionContext.setLease(this.lease);

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -110,7 +110,7 @@ public abstract class PartitionPump
     
     public abstract void specializedShutdown(CloseReason reason);
     
-    public void onEvents(Iterable<EventData> events)
+    protected void onEvents(Iterable<EventData> events)
 	{
     	// Assumes that javaClient will call with null on receive timeout. Currently it doesn't call at all.
     	// See note on EventProcessorOptions.
@@ -150,4 +150,13 @@ public abstract class PartitionPump
         	this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, "Got exception from onEvents", e);
         }
 	}
+    
+    protected void onError(Throwable error)
+    {
+    	// This handler is called when javaClient calls the error handler we have installed.
+    	// JavaClient can only do that when execution is down in javaClient. Therefore no onEvents
+    	// call can be in progress right now. JavaClient will not get control back until this handler
+    	// returns, so there will be no calls to onEvents until after the user's error handler has returned.
+    	this.processor.onError(this.partitionContext, error);
+    }
 }

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -9,52 +9,21 @@ import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
-import java.util.concurrent.Callable;
 
 
 class Pump
 {
     private EventProcessorHost host;
 
-    private ConcurrentHashMap<String, LeaseAndPump> pumpStates;
+    private ConcurrentHashMap<String, PartitionPump> pumpStates;
     
     private Class<?> pumpClass = EventHubPartitionPump.class;
     
-    private class LeaseAndPump implements Callable<Void>
-    {
-    	private Lease lease;
-    	private PartitionPump pump;
-    	
-    	public LeaseAndPump(Lease lease, PartitionPump pump)
-    	{
-    		this.lease = lease;
-    		this.pump = pump;
-    	}
-    	
-    	public void setLease(Lease newLease)
-    	{
-    		this.lease = newLease;
-    		this.pump.setLease(newLease);
-    	}
-    	
-    	public PartitionPump getPump()
-    	{
-    		return this.pump;
-    	}
-    	
-		@Override
-		public Void call() throws Exception
-		{
-			this.pump.startPump();
-			return null;
-		}
-    }
-
     public Pump(EventProcessorHost host)
     {
         this.host = host;
 
-        this.pumpStates = new ConcurrentHashMap<String, LeaseAndPump>();
+        this.pumpStates = new ConcurrentHashMap<String, PartitionPump>();
     }
     
     public <T extends PartitionPump> void setPumpClass(Class<T> pumpClass)
@@ -64,11 +33,11 @@ class Pump
 
     public void addPump(String partitionId, Lease lease) throws Exception
     {
-    	LeaseAndPump capturedState = this.pumpStates.get(partitionId);
-    	if (capturedState != null)
+    	PartitionPump capturedPump = this.pumpStates.get(partitionId);
+    	if (capturedPump != null)
     	{
     		// There already is a pump. Make sure the pump is working and replace the lease.
-    		if ((capturedState.getPump().getPumpStatus() == PartitionPumpStatus.PP_ERRORED) || capturedState.getPump().isClosing())
+    		if ((capturedPump.getPumpStatus() == PartitionPumpStatus.PP_ERRORED) || capturedPump.isClosing())
     		{
     			// The existing pump is bad. Remove it and create a new one.
     			removePump(partitionId, CloseReason.Shutdown).get();
@@ -78,7 +47,7 @@ class Pump
     		{
     			// Pump is working, just replace the lease.
     			this.host.logWithHostAndPartition(Level.FINE, partitionId, "updating lease for pump");
-    			capturedState.setLease(lease);
+    			capturedPump.setLease(lease);
     		}
     	}
     	else
@@ -92,22 +61,21 @@ class Pump
     {
 		PartitionPump newPartitionPump = (PartitionPump)this.pumpClass.newInstance();
 		newPartitionPump.initialize(this.host, lease);
-		LeaseAndPump newPump = new LeaseAndPump(lease, newPartitionPump);
-		EventProcessorHost.getExecutorService().submit(newPump);
-        this.pumpStates.put(partitionId, newPump); // do the put after start, if the start fails then put doesn't happen
+		EventProcessorHost.getExecutorService().submit(() -> newPartitionPump.startPump());
+        this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
 		this.host.logWithHostAndPartition(Level.INFO, partitionId, "created new pump");
     }
     
     public Future<?> removePump(String partitionId, final CloseReason reason)
     {
     	Future<?> retval = null;
-    	LeaseAndPump capturedState = this.pumpStates.get(partitionId);
-    	if (capturedState != null)
+    	PartitionPump capturedPump = this.pumpStates.get(partitionId);
+    	if (capturedPump != null)
     	{
 			this.host.logWithHostAndPartition(Level.INFO, partitionId, "closing pump for reason " + reason.toString());
-    		if (!capturedState.getPump().isClosing())
+    		if (!capturedPump.isClosing())
     		{
-    			retval = EventProcessorHost.getExecutorService().submit(() -> capturedState.getPump().shutdown(reason));
+    			retval = EventProcessorHost.getExecutorService().submit(() -> capturedPump.shutdown(reason));
     		}
     		// else, pump is already closing/closed, don't need to try to shut it down again
     		

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/TemporaryTest.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/TemporaryTest.java
@@ -1,0 +1,488 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import com.microsoft.azure.eventhubs.EventData;
+
+public class TemporaryTest
+{
+    public static void main(String args[])
+    {
+    	final int hostCount = 1;
+    	
+    	int runCase = 3;
+    	boolean useInMemory = false;
+    	boolean useEH = true;
+
+    	String ehConsumerGroup = "$Default";
+    	String ehNamespace = "";
+    	String ehEventhub = "";
+    	String ehKeyname = "";
+    	String ehKey = "";
+    	String storageConnectionString = "this is not a valid storage connection string";
+    	
+    	if (runCase == 1)
+    	{
+    		ILeaseManager leaseMgr = null;
+    		ICheckpointManager checkpointMgr = null;
+    		if (useInMemory)
+    		{
+    			leaseMgr = new InMemoryLeaseManager();
+    			checkpointMgr = new InMemoryCheckpointManager();
+    		}
+    		else
+    		{
+    			AzureStorageCheckpointLeaseManager azMgr = new AzureStorageCheckpointLeaseManager(storageConnectionString);
+    			leaseMgr = azMgr;
+    			checkpointMgr = azMgr;
+    		}
+	    	EventProcessorHost blah = new EventProcessorHost("namespace", "eventhub", "keyname", "key", "$Default", checkpointMgr, leaseMgr);
+	    	try
+	    	{
+	    		if (useInMemory)
+	    		{
+	    			((InMemoryLeaseManager)leaseMgr).initialize(blah);
+	    			((InMemoryCheckpointManager)checkpointMgr).initialize(blah);
+	    		}
+	    		else
+	    		{
+	    			((AzureStorageCheckpointLeaseManager)leaseMgr).initialize(blah);
+	    		}
+			}
+	    	catch (Exception e)
+	    	{
+	    		System.out.println("Initialize failed " + e.toString());
+	    		e.printStackTrace();
+			}
+
+	    	final int partitionCount = 8;
+	    	basicLeaseManagerTest(leaseMgr, partitionCount, useInMemory);
+    	}
+    	else if (runCase == 2)
+    	{
+    		ILeaseManager leaseMgr1 = null;
+    		ILeaseManager leaseMgr2 = null;
+    		ICheckpointManager checkMgr1 = null;
+    		ICheckpointManager checkMgr2 = null;
+    		if (useInMemory)
+    		{
+    			leaseMgr1 = new InMemoryLeaseManager();
+    			checkMgr1 = new InMemoryCheckpointManager();
+    			leaseMgr2 = new InMemoryLeaseManager();
+    			checkMgr2 = new InMemoryCheckpointManager();
+    		}
+    		else
+    		{
+    			AzureStorageCheckpointLeaseManager azMgr1 = new AzureStorageCheckpointLeaseManager(storageConnectionString);
+    			leaseMgr1 = azMgr1;
+    			checkMgr1 = azMgr1;
+		    	AzureStorageCheckpointLeaseManager azMgr2 = new AzureStorageCheckpointLeaseManager(storageConnectionString);
+		    	leaseMgr2 = azMgr2;
+		    	checkMgr2 = azMgr2;
+    		}
+	    	EventProcessorHost blah1 = new EventProcessorHost("namespace", "eventhub", "keyname", "key", "$Default", checkMgr1, leaseMgr1);
+	    	EventProcessorHost blah2 = new EventProcessorHost("namespace", "eventhub", "keyname", "key", "$Default", checkMgr2, leaseMgr2);
+	    	try
+	    	{
+	    		if (useInMemory)
+	    		{
+	    			((InMemoryLeaseManager)leaseMgr1).initialize(blah1);
+	    			((InMemoryCheckpointManager)checkMgr1).initialize(blah1);
+	    			((InMemoryLeaseManager)leaseMgr2).initialize(blah2);
+	    			((InMemoryCheckpointManager)checkMgr2).initialize(blah2);
+	    		}
+	    		else
+	    		{
+	    			((AzureStorageCheckpointLeaseManager)leaseMgr1).initialize(blah1);
+	    			((AzureStorageCheckpointLeaseManager)leaseMgr2).initialize(blah2);
+	    		}
+			}
+	    	catch (Exception e)
+	    	{
+	    		System.out.println("Initialize failed " + e.toString());
+	    		e.printStackTrace();
+			}
+	    	
+	    	stealLeaseTest(leaseMgr1, checkMgr1, leaseMgr2, checkMgr2, useInMemory);
+    	}
+    	else if (runCase == 3)
+    	{
+    		EventProcessorHost[] hosts = new EventProcessorHost[hostCount];
+    		for (int i = 0; i < hostCount; i++)
+    		{
+        		if (useInMemory)
+        		{
+        			InMemoryLeaseManager leaseMgr = new InMemoryLeaseManager();
+        			InMemoryCheckpointManager checkMgr = new InMemoryCheckpointManager();
+        			hosts[i] = new EventProcessorHost(ehNamespace, ehEventhub, ehKeyname, ehKey, ehConsumerGroup, checkMgr, leaseMgr);
+        			leaseMgr.initialize(hosts[i]);
+        			checkMgr.initialize(hosts[i]);
+        		}
+        		else
+        		{
+        			hosts[i] = new EventProcessorHost(ehNamespace, ehEventhub, ehKeyname, ehKey, ehConsumerGroup, storageConnectionString); 
+        		}
+    			if (!useEH)
+    			{
+    				hosts[i].setPumpClass(SyntheticPump.class);
+    			}
+    		}
+    		processMessages(hosts);
+    	}
+    	
+        System.out.println("End of sample");
+    }
+    
+    private static void stealLeaseTest(ILeaseManager leaseMgr1, ICheckpointManager checkMgr1, ILeaseManager leaseMgr2, ICheckpointManager checkMgr2, boolean useInMemory)
+    {
+    	try
+    	{
+	    	System.out.println("Lease store may not exist");
+			Boolean boolret = leaseMgr1.leaseStoreExists().get();
+			System.out.println("leaseStoreExists() returned " + boolret);
+			
+			System.out.println("Create lease store if not exists");
+			boolret = leaseMgr1.createLeaseStoreIfNotExists().get();
+			System.out.println("createLeaseStoreIfNotExists() returned " + boolret);
+	
+	    	System.out.println("Lease store should exist now");
+			boolret = leaseMgr1.leaseStoreExists().get();
+			System.out.println("leaseStoreExists() returned " + boolret);
+
+			if (useInMemory)
+			{
+		    	System.out.println("Checkpoint store may not exist");
+				boolret = checkMgr1.checkpointStoreExists().get();
+				System.out.println("checkpointStoreExists() returned " + boolret);
+				
+				System.out.println("Create checkpoint store if not exists");
+				boolret = checkMgr1.createCheckpointStoreIfNotExists().get();
+				System.out.println("createCheckpointStoreIfNotExists() returned " + boolret);
+		
+		    	System.out.println("Checkpoint store should exist now");
+				boolret = checkMgr1.checkpointStoreExists().get();
+				System.out.println("checkpointStoreExists() returned " + boolret);
+			}
+			
+			System.out.print("Mgr1 making sure lease for 0 exists... ");
+			Lease mgr1Lease = leaseMgr1.createLeaseIfNotExists("0").get();
+			System.out.println("OK");
+			
+			if (useInMemory)
+			{
+				System.out.print("Mgr1 making sure checkpoint for 0 exists... ");
+				checkMgr1.createCheckpointIfNotExists("0").get();
+				System.out.println("OK");
+			}
+			
+			System.out.print("Mgr2 get lease... ");
+			Lease mgr2Lease = leaseMgr2.getLease("0").get();
+			System.out.println("OK");
+
+			System.out.print("Mgr1 acquiring lease... ");
+			boolret = leaseMgr1.acquireLease(mgr1Lease).get();
+			System.out.println(boolret);
+			System.out.println("Lease token is " + mgr1Lease.getToken());
+			
+			System.out.println("Waiting for lease on 0 to expire.");
+			int x = 1;
+			while (!mgr1Lease.isExpired())
+			{
+				Thread.sleep(5000);
+				System.out.println("Still waiting for lease on 0 to expire: " + (5 * x++));
+			}
+			System.out.println("Expired!");
+
+			System.out.print("Mgr2 acquiring lease... ");
+			boolret = leaseMgr2.acquireLease(mgr2Lease).get();
+			System.out.println(boolret);
+			System.out.println("Lease token is " + mgr2Lease.getToken());
+			
+			System.out.print("Mgr1 tries to renew lease... ");
+			boolret = leaseMgr1.renewLease(mgr1Lease).get();
+			System.out.println(boolret);
+			
+			System.out.print("Mgr1 gets current lease data in order to steal it... ");
+			mgr1Lease = leaseMgr1.getLease(mgr1Lease.getPartitionId()).get();
+			System.out.println("OK");
+			
+			System.out.print("Mgr1 tries to steal lease... ");
+			boolret = leaseMgr1.acquireLease(mgr1Lease).get();
+			System.out.println(boolret);
+			System.out.println("Lease token is " + mgr1Lease.getToken());
+			
+			Checkpoint check1 = checkMgr1.getCheckpoint("0").get();
+			System.out.println("Checkpoint currently at offset: " + check1.getOffset() + " seqNo: " + check1.getSequenceNumber());
+			check1.setOffset(((Integer)(Integer.parseInt(check1.getOffset()) + 500)).toString());
+			check1.setSequenceNumber(check1.getSequenceNumber() + 5);
+			System.out.println("Checkpoint changed to offset: " + check1.getOffset() + " seqNo: " + check1.getSequenceNumber());
+			System.out.print("Mgr1 checkpointing... ");
+			checkMgr1.updateCheckpoint(check1).get();
+			System.out.println("done");
+			
+			System.out.print("Mgr2 gets current lease data in order to steal it... ");
+			mgr2Lease = leaseMgr2.getLease("0").get();
+			System.out.println("OK");
+			
+			System.out.print("Mgr2 tries to steal lease... ");
+			boolret = leaseMgr2.acquireLease(mgr2Lease).get();
+			System.out.println(boolret);
+			System.out.println("Lease token is " + mgr2Lease.getToken());
+			Checkpoint check2 = checkMgr2.getCheckpoint("0").get();
+			System.out.println("Got checkpoint of offset: " + check2.getOffset() + " seqNo: " + check2.getSequenceNumber());
+			
+			System.out.print("Mgr2 releasing lease... ");
+			boolret = leaseMgr2.releaseLease(mgr2Lease).get();
+			System.out.println(boolret);
+
+			System.out.print("Mgr1 releasing lease... ");
+			boolret = leaseMgr2.releaseLease(mgr1Lease).get();
+			System.out.println(boolret);
+
+			check2 = checkMgr2.getCheckpoint("0").get();
+			System.out.println("Got checkpoint of offset: " + check2.getOffset() + " seqNo: " + check2.getSequenceNumber());
+    	}
+    	catch (Exception e)
+    	{
+        	System.out.println("Sample caught " + e.toString());
+        	StackTraceElement[] stack = e.getStackTrace();
+        	for (int i = 0; i < stack.length; i++)
+        	{
+        		System.out.println(stack[i].toString());
+        	}
+    	}
+    }
+    
+    private static void processMessages(EventProcessorHost[] hosts)
+    {
+    	int hostCount = hosts.length;
+    	
+    	for (int i = 0; i < hostCount; i++)
+    	{
+    		System.out.println("Registering host " + i + " named " + hosts[i].getHostName());
+    		hosts[i].registerEventProcessor(EventProcessor.class);
+    		try
+    		{
+    			Thread.sleep(3000);
+    		}
+    		catch (InterruptedException e1)
+    		{
+    			// Watch me not care
+    		}
+    	}
+
+        System.out.println("Press enter to stop");
+        try
+        {
+            System.in.read();
+            for (int i = 0; i < hostCount; i++)
+            {
+	            System.out.println("Calling unregister " + i);
+	            hosts[i].unregisterEventProcessor();
+	            System.out.println("Completed");
+            }
+        }
+        catch(Exception e)
+        {
+            System.out.println(e.toString());
+            e.printStackTrace();
+        }
+    }
+    
+    private static void basicLeaseManagerTest(ILeaseManager mgr, int partitionCount, boolean useInMemory)
+    {
+    	try
+    	{
+        	System.out.println("Store may not exist");
+			Boolean boolret = mgr.leaseStoreExists().get();
+			System.out.println("getStoreExists() returned " + boolret);
+			
+			System.out.println("Create store if not exists");
+			boolret = mgr.createLeaseStoreIfNotExists().get();
+			System.out.println("createStoreIfNotExists() returned " + boolret);
+
+        	System.out.println("Store should exist now");
+			boolret = mgr.leaseStoreExists().get();
+			System.out.println("getStoreExists() returned " + boolret);
+			
+			Lease[] leases = new Lease[partitionCount];
+			for (Integer i = 0; i < partitionCount; i++)
+			{
+				System.out.print("Creating lease for partition " + i + "... ");
+				Lease createdLease = mgr.createLeaseIfNotExists(i.toString()).get();
+				leases[i] = createdLease;
+				System.out.println("OK");
+			}
+			
+			for (int i = 0; i < partitionCount; i++)
+			{
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state before: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+				System.out.print("Acquiring lease for partition " + i + "... ");
+				boolret = mgr.acquireLease(leases[i]).get();
+				System.out.println(boolret.toString());
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state after: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+			}
+			
+			System.out.print("Sleeping... ");
+			Thread.sleep(5000);
+			System.out.println("done");
+			
+			for (int i = 0; i < partitionCount; i++)
+			{
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state before: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+				System.out.print("Renewing lease for partition " + i + "... ");
+				boolret = mgr.renewLease(leases[i]).get();
+				System.out.println(boolret.toString());
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state after: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+			}
+			
+			System.out.println("Waiting for lease on 0 to expire.");
+			int x = 1;
+			while (!leases[0].isExpired())
+			{
+				Thread.sleep(5000);
+				System.out.println("Still waiting for lease on 0 to expire: " + (5 * x++));
+				for (int i = 1; i < partitionCount; i++)
+				{
+					System.out.print("   Renewing lease for partition " + i + "... ");
+					boolret = mgr.renewLease(leases[i]).get();
+					System.out.println(boolret.toString());
+				}
+			}
+			System.out.println("Expired!");
+			
+			for (int i = 0; i < partitionCount; i++)
+			{
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state before: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+				System.out.print("Releasing lease for partition " + i + "... ");
+				boolret = mgr.releaseLease(leases[i]).get();
+				System.out.println(boolret.toString());
+				if (!useInMemory)
+				{
+					System.out.println("Partition " + i + " state after: " + ((AzureBlobLease)leases[i]).getStateDebug());
+				}
+			}
+    	}
+    	catch (Exception e)
+    	{
+        	System.out.println("Sample caught " + e.toString());
+        	StackTraceElement[] stack = e.getStackTrace();
+        	for (int i = 0; i < stack.length; i++)
+        	{
+        		System.out.println(stack[i].toString());
+        	}
+		}
+    }
+    
+    public static class SyntheticPump extends PartitionPump
+    {
+    	Future<Void> producer = null;
+    	boolean keepGoing = true;
+
+		@Override
+		public void specializedStartPump()
+		{
+			this.producer = EventProcessorHost.getExecutorService().submit(() -> produceMessages());
+		}
+
+		@Override
+		public void specializedShutdown(CloseReason reason)
+		{
+			this.keepGoing = false;
+			try
+			{
+				this.producer.get();
+			}
+			catch (InterruptedException | ExecutionException e)
+			{
+				System.out.println("SyntheticPump shutdown failure" + e.toString());
+				e.printStackTrace();
+			}
+		}
+		
+		private Void produceMessages()
+		{
+			ArrayList<EventData> events = new ArrayList<EventData>();
+			int eventNumber = 0;
+			
+			while (this.keepGoing)
+			{
+				events.clear();
+				String eventBody = "Event " + eventNumber + " on partition " + this.lease.getPartitionId();
+				eventNumber++;
+				EventData event = new EventData(eventBody.getBytes());
+				//event.fakeReceivedMessage(Integer.toString(eventNumber * 75), eventNumber);
+				events.add(event);
+				onEvents(events);
+				
+				try
+				{
+					Thread.sleep(3000);
+				}
+				catch (InterruptedException e)
+				{
+					// Watch me not care
+				}
+			}
+			
+			return null;
+		}
+    }
+
+    public static class EventProcessor implements IEventProcessor
+    {
+    	private int checkpointBatchingCount = 0;
+    	
+        public void onOpen(PartitionContext context) throws Exception
+        {
+            String hostname = context.getLease().getOwner();
+        	System.out.println("SAMPLE: Partition " + context.getPartitionId() + " is opening for host " + hostname.substring(hostname.length() - 4));
+        }
+
+        public void onClose(PartitionContext context, CloseReason reason) throws Exception
+        {
+            String hostname = context.getLease().getOwner();
+            System.out.println("SAMPLE: Partition " + context.getPartitionId() + " is closing for reason " + reason.toString() + " for host " + hostname.substring(hostname.length() - 4));
+        }
+
+        public void onEvents(PartitionContext context, Iterable<EventData> messages) throws Exception
+        {
+            String hostname = context.getLease().getOwner();
+            hostname = hostname.substring(hostname.length() - 4);
+            System.out.println("SAMPLE: Partition " + context.getPartitionId() + " got message batch for host " + hostname);
+            int messageCount = 0;
+            for (EventData data : messages)
+            {
+                System.out.print("SAMPLE (" + hostname + "," + context.getPartitionId() + ",");
+                System.out.print(data.getSystemProperties().getOffset() + "," + data.getSystemProperties().getSequenceNumber() + "): ");
+                System.out.println(new String(data.getBody(), "UTF8"));
+                messageCount++;
+                this.checkpointBatchingCount++;
+                if ((checkpointBatchingCount % 5) == 0)
+                {
+                	System.out.println("SAMPLE: Partition " + context.getPartitionId() + " checkpointing at " +
+               			data.getSystemProperties().getOffset() + "," + data.getSystemProperties().getSequenceNumber());
+                	context.checkpoint(data);
+                }
+            }
+            System.out.println("SAMPLE: Partition " + context.getPartitionId() + " batch size was " + messageCount + " for host " + hostname);
+        }
+    }
+}

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/TemporaryTest.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/TemporaryTest.java
@@ -10,18 +10,17 @@ public class TemporaryTest
 {
     public static void main(String args[])
     {
-    	final int hostCount = 1;
-    	
+    	final int hostCount = 2;
     	int runCase = 3;
-    	boolean useInMemory = false;
-    	boolean useEH = true;
+    	final boolean useInMemory = false;
+    	final boolean useEH = true;
 
-    	String ehConsumerGroup = "$Default";
-    	String ehNamespace = "";
-    	String ehEventhub = "";
-    	String ehKeyname = "";
-    	String ehKey = "";
-    	String storageConnectionString = "this is not a valid storage connection string";
+    	final String ehConsumerGroup = "$Default";
+    	final String ehNamespace = "";
+    	final String ehEventhub = "";
+    	final String ehKeyname = "";
+    	final String ehKey = "";
+    	final String storageConnectionString = "this is not a valid storage connection string";
     	
     	if (runCase == 1)
     	{
@@ -450,18 +449,21 @@ public class TemporaryTest
     {
     	private int checkpointBatchingCount = 0;
     	
+    	@Override
         public void onOpen(PartitionContext context) throws Exception
         {
             String hostname = context.getLease().getOwner();
         	System.out.println("SAMPLE: Partition " + context.getPartitionId() + " is opening for host " + hostname.substring(hostname.length() - 4));
         }
 
+    	@Override
         public void onClose(PartitionContext context, CloseReason reason) throws Exception
         {
             String hostname = context.getLease().getOwner();
             System.out.println("SAMPLE: Partition " + context.getPartitionId() + " is closing for reason " + reason.toString() + " for host " + hostname.substring(hostname.length() - 4));
         }
 
+    	@Override
         public void onEvents(PartitionContext context, Iterable<EventData> messages) throws Exception
         {
             String hostname = context.getLease().getOwner();
@@ -470,9 +472,8 @@ public class TemporaryTest
             int messageCount = 0;
             for (EventData data : messages)
             {
-                System.out.print("SAMPLE (" + hostname + "," + context.getPartitionId() + ",");
-                System.out.print(data.getSystemProperties().getOffset() + "," + data.getSystemProperties().getSequenceNumber() + "): ");
-                System.out.println(new String(data.getBody(), "UTF8"));
+                System.out.println("SAMPLE (" + hostname + "," + context.getPartitionId() + "," + data.getSystemProperties().getOffset() + "," +
+                		data.getSystemProperties().getSequenceNumber() + "): " + new String(data.getBody(), "UTF8"));
                 messageCount++;
                 this.checkpointBatchingCount++;
                 if ((checkpointBatchingCount % 5) == 0)
@@ -484,5 +485,11 @@ public class TemporaryTest
             }
             System.out.println("SAMPLE: Partition " + context.getPartitionId() + " batch size was " + messageCount + " for host " + hostname);
         }
+    	
+    	@Override
+    	public void onError(PartitionContext context, Throwable error)
+    	{
+    		System.out.println("SAMPLE: Partition " + context.getPartitionId() + " onError: " + error.toString());
+    	}
     }
 }


### PR DESCRIPTION
Remove dummy ability to manually set number of partitions.
Move test into project to avoid problems when a private javaClient is required.
Add tracing to getPartitionIds.
Fix: when checkpointing with explicit event, use that event in regression check.
Make checkpointing async with one central checkpoint update writer per host.
Trace paritition stealing via epoch more gracefully.
Implement EventProcessorOptions or mark as unsupportable for now. User error handler is on IEventProcessor instead of EventProcessorOptions.
Minor cleanups, get rid of unused stuff.