### PR TITLE
Fix stuck send issue when sends() are parked at very high rate on MessageSender

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpSender.java
@@ -8,7 +8,7 @@ import org.apache.qpid.proton.amqp.transport.*;
 
 public interface IAmqpSender extends IAmqpLink
 {
-	void onFlow(int credit);
+	void onFlow();
 	
 	void onSendComplete(final byte[] deliveryTag, final DeliveryState outcome);
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
@@ -90,11 +90,11 @@ public class SendLinkHandler extends BaseLinkHandler
 			}
 		}
 		
-		Sender sender = (Sender) event.getLink();
-		this.msgSender.onFlow(sender.getRemoteCredit());
+		this.msgSender.onFlow();
 		
 		if(TRACE_LOGGER.isLoggable(Level.FINEST))
         {
+			Sender sender = event.getSender();
 			TRACE_LOGGER.log(Level.FINEST, "linkName[" + sender.getName() + "], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getCredit()+ "]");
         }
 	}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,9 +12,9 @@
 	<url>https://github.com/Azure/azure-event-hubs</url>
 	
 	<properties>
-		<proton-j-version>0.12.1</proton-j-version>
+		<proton-j-version>0.12.2</proton-j-version>
 	  	<junit-version>4.10</junit-version>
-		<client-current-version>0.6.6</client-current-version>
+		<client-current-version>0.6.7</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
When sends are parked on the MessageSender - the LinkCredit accounting encountered a concurrency issue.
This PR addresses the issue: https://github.com/Azure/azure-event-hubs/issues/112 