### PR TITLE
properties lost in translation from AmqpMessage

### DIFF
--- a/node/send_receive/lib/eventdata.js
+++ b/node/send_receive/lib/eventdata.js
@@ -8,7 +8,7 @@
  * @classdesc Constructs a {@linkcode EventData} object.
  * @param {String}  body   The event payload as a byte array.
  */
-function EventData(body, systemProperties) {
+function EventData(body, systemProperties, properties) {
   Object.defineProperties(this, {
     'partitionKey': {
       get: function () {
@@ -42,7 +42,7 @@ function EventData(body, systemProperties) {
       }
     },
     'properties': {
-      value: null,
+      value: properties,
       writable: true
     },
     'sequenceNumber': {
@@ -62,7 +62,7 @@ function EventData(body, systemProperties) {
 }
 
 EventData.fromAmqpMessage = function (msg) {
-  return new EventData(msg.body, msg.annotations.value);
+  return new EventData(msg.body, msg.annotations.value, msg.properties);
 };
 
 module.exports = EventData;


### PR DESCRIPTION
Fixes #120

I didn't find any unit tests to run but my own test worked. here are the relevant parts of the code.  

Device side

```javascript
var Protocol = require("azure-iot-device-amqp").Amqp;
var Client = require("azure-iot-device").Client;
var Message = require("azure-iot-common").Message;
var uuid = require("uuid");

// Create IoT Hub client
var client = Client.fromConnectionString(process.env.IOT_DEVICE_CONNECTIONSTRING, Protocol);

function sendMessage(msg) {
  var message = new Message(JSON.stringify(msg));
  message.messageId = uuid.v4();

  client.sendEvent(message, function (err, result) {
    if (err) {
      console.error("send error:", err.toString());
    }
  });
};
```

Server side

```javascript
const util = require("util");
const EventEmitter = require("events");
const eventhub = require("azure-event-hubs");
const uuid = require("uuid");

const connectionString = process.env.IOT_HUB_CONNECTIONSTRING;

// privates members
var ehClient = null;

//constructor
function IoTHub() {
  var self = this;
  var receiveAfterTime = Date.now() - 5000;
  ehClient = eventhub.Client.fromConnectionString(connectionString);

//...other stuff not event hub related

  ehClient.open()
  .then(function () {
    return ehClient.getPartitionIds();
  })
  .then(function (partitionIds) {
    return partitionIds.map(function (partitionId) {
      return ehClient.createReceiver(
        "$Default"
        , partitionId
        , { "startAfterTime": receiveAfterTime }
      )
      .then(function (receiver) {
        receiver.on("errorReceived", function (err) {
          self.emit("error", err);
        });

        receiver.on("message", function (eventData) {
            var message = Object.assign({
              "messageId": eventData.properties["messageId"],
              "datestamp": eventData.enqueuedTimeUtc,
              "deviceId": eventData.systemProperties["iothub-connection-device-id"]
            }, eventData.body);
            console.log(message, eventData.properties);
            //self.emit("message", message);
        });
      });
    });
  })
  .catch(function (err) {
    console.error(err.toString());
    ehClient.close();
    ehClient = null;
  });
};
util.inherits(IoTHub, EventEmitter);
```