### PR TITLE
Updates based on comments from Serkant.

### DIFF
--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
@@ -17,9 +17,9 @@ public class AzureBlobLease extends Lease
 	private String offset = PartitionReceiver.START_OF_STREAM;
 	private long sequenceNumber = 0;
 	
-	public AzureBlobLease(String eventHub, String consumerGroup, String partitionId, CloudBlockBlob blob)
+	public AzureBlobLease(String partitionId, CloudBlockBlob blob)
 	{
-		super(eventHub, consumerGroup, partitionId);
+		super(partitionId);
 		this.blob = blob;
 	}
 	

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
@@ -220,7 +220,7 @@ public class AzureStorageCheckpointLeaseManager implements ICheckpointManager, I
     	try
     	{
     		CloudBlockBlob leaseBlob = this.consumerGroupDirectory.getBlockBlobReference(partitionId);
-    		returnLease = new AzureBlobLease(this.host.getEventHubPath(), this.host.getConsumerGroupName(), partitionId, leaseBlob);
+    		returnLease = new AzureBlobLease(partitionId, leaseBlob);
     		String jsonLease = this.gson.toJson(returnLease);
     		this.host.logWithHostAndPartition(Level.INFO, partitionId,
     				"CreateLeaseIfNotExist - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " + this.host.getConsumerGroupName());

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
@@ -119,7 +119,7 @@ public class InMemoryLeaseManager implements ILeaseManager
         else
         {
         	this.host.logWithHostAndPartition(Level.INFO, partitionId, "createLeaseIfNotExists() creating new lease");
-        	InMemoryLease storeLease = new InMemoryLease(this.host.getEventHubPath(), this.host.getConsumerGroupName(), partitionId);
+        	InMemoryLease storeLease = new InMemoryLease(partitionId);
             storeLease.setEpoch(0L);
             storeLease.setOwner("");
             InMemoryLeaseStore.singleton.inMemoryLeases.put(partitionId, storeLease);
@@ -300,9 +300,9 @@ public class InMemoryLeaseManager implements ILeaseManager
     {
     	private long expirationTimeMillis = 0;
     	
-		public InMemoryLease(String eventHub, String consumerGroup, String partitionId)
+		public InMemoryLease(String partitionId)
 		{
-			super(eventHub, consumerGroup, partitionId);
+			super(partitionId);
 		}
 		
 		public InMemoryLease(InMemoryLease source)

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
@@ -7,18 +7,14 @@ package com.microsoft.azure.eventprocessorhost;
 
 public class Lease
 {
-    private String eventHubPath;
-    private String consumerGroup;
     private String partitionId;
 
     private long epoch;
     private String owner;
     private String token;
 
-    public Lease(String eventHub, String consumerGroup, String partitionId)
+    public Lease(String partitionId)
     {
-        this.eventHubPath = eventHub;
-        this.consumerGroup = consumerGroup;
         this.partitionId = partitionId;
 
         this.epoch = 0;
@@ -28,8 +24,6 @@ public class Lease
 
     public Lease(Lease source)
     {
-        this.eventHubPath = source.eventHubPath;
-        this.consumerGroup = source.consumerGroup;
         this.partitionId = source.partitionId;
 
         this.epoch = source.epoch;
@@ -66,16 +60,6 @@ public class Lease
     public String getPartitionId()
     {
         return this.partitionId;
-    }
-
-    public String getEventHubPath()
-    {
-        return this.eventHubPath;
-    }
-
-    public String getConsumerGroup()
-    {
-        return this.consumerGroup;
     }
 
     public String getToken()


### PR DESCRIPTION
Updates based on comments from Serkant.
 6081116: simpler algorithm for distributing partitions
 Lease does not need event hub name or consumer group, removed.