### PR TITLE
Allow EventHub path to be specified when using IoT Hub connection string

### DIFF
--- a/node/send_receive/lib/config.js
+++ b/node/send_receive/lib/config.js
@@ -16,7 +16,7 @@ function ConnectionConfig(connectionString, path) {
     this.host = cn.HostName;
     var hubName = this.host.split('.')[0];
     this.sharedAccessSignature = aziot.SharedAccessSignature.create(this.host, this.keyName, this.key, aziot.anHourFromNow());
-    this.path = 'messages/events/';
+    this.path = path || 'messages/events/';
     this.saslPlainUri  = 'amqps://' +
                         encodeURIComponent(this.keyName) +
                         '%40sas.root.' +

--- a/node/send_receive/tests/config_test.js
+++ b/node/send_receive/tests/config_test.js
@@ -32,4 +32,9 @@ describe('ConnectionConfig', function () {
     var config = new ConnectionConfig('', 'abc');
     config.should.have.property('path').that.equals('abc');
   });
+
+  it('populates path from the path argument if provided when using an Iot Hub connection string', function () {
+    var config = new ConnectionConfig('HostName=hostname.azure-devices.net;SharedAccessKeyName=sakName;SharedAccessKey=sak', 'custom_path');
+    config.should.have.property('path').that.equals('custom_path');
+  });
 });


### PR DESCRIPTION
Currently, the path for an event hub when using an IoT Hub connection string is hardcoded to `messages/events/`. However, there are multiple different valid paths when using an IoT Hub (`messages/operationsMonitoringEvents/`, `messages/deviceBound`, etc.).

This change allows the user to provide their own path when using an IoT Hub, defaulting to `messages/events/` when none is provided.