### PR TITLE
Sender timeout issues

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -4,13 +4,23 @@
  */
 package com.microsoft.azure.eventhubs;
 
-import java.time.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.function.*;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.qpid.proton.message.Message;
-import com.microsoft.azure.servicebus.*;
+
+import com.microsoft.azure.servicebus.ClientEntity;
+import com.microsoft.azure.servicebus.MessageReceiver;
+import com.microsoft.azure.servicebus.MessagingFactory;
+import com.microsoft.azure.servicebus.ServiceBusException;
+import com.microsoft.azure.servicebus.StringUtil;
 
 /**
  * This is a logical representation of receiving from a EventHub partition.

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/AuthorizationFailedException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/AuthorizationFailedException.java
@@ -6,6 +6,8 @@ package com.microsoft.azure.servicebus;
 
 public class AuthorizationFailedException extends ServiceBusException
 {
+	private static final long serialVersionUID = 1L;
+
 	AuthorizationFailedException()
 	{
 		super(false);

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -42,4 +42,5 @@ public final class ClientConstants
 	public final static boolean DEFAULT_IS_TRANSIENT = true;
 	
 	public final static int REACTOR_IO_POLL_TIMEOUT = 20;
+	public final static int SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS = 10;
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
@@ -4,9 +4,17 @@
  */
 package com.microsoft.azure.servicebus;
 
-import java.util.concurrent.*;
-import org.apache.qpid.proton.amqp.transport.*;
-import com.microsoft.azure.servicebus.amqp.*;
+import java.time.ZonedDateTime;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+
+import com.microsoft.azure.servicebus.amqp.AmqpErrorCode;
+import com.microsoft.azure.servicebus.amqp.AmqpException;
 
 final class ExceptionUtil
 {
@@ -94,5 +102,18 @@ final class ExceptionUtil
 		}
 		
 		future.completeExceptionally(exception);
+	}
+	
+	// not a specific message related error
+	static boolean isGeneralSendError(Symbol amqpError)
+	{
+		return (amqpError == ClientConstants.SERVER_BUSY_ERROR 
+				|| amqpError == ClientConstants.TIMEOUT_ERROR 
+				|| amqpError == AmqpErrorCode.ResourceLimitExceeded);
+	}
+	
+	static String getTrackingIDAndTimeToLog()
+	{
+		return String.format(Locale.US, "TrackingId: %s, at: %s", UUID.randomUUID().toString(), ZonedDateTime.now()); 
 	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ITimeoutErrorHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ITimeoutErrorHandler.java
@@ -4,7 +4,10 @@
  */
 package com.microsoft.azure.servicebus;
 
-// recover client from the underlying TransportStack-Stuck situation
+// multiple issues were identified in the proton-j layer which could lead to a stuck state in Transport
+// https://issues.apache.org/jira/browse/PROTON-1185
+// https://issues.apache.org/jira/browse/PROTON-1171
+// This handler is built to - recover client from the underlying TransportStack-Stuck situation
 public interface ITimeoutErrorHandler
 {
 	public void reportTimeoutError();

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.servicebus;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -16,7 +17,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -144,7 +144,18 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 				{
 					// workaround to push the sendflow-performative to reactor
 					MessageReceiver.this.receiveLink.flow(0);
-					MessageReceiver.this.stuckTransportHandler.reportTimeoutError();
+					
+					// we have a known issue with proton libraries where transport layer is stuck while Sending Flow
+					// to workaround this - we built a mechanism to reset the transport whenever we encounter this
+					// https://issues.apache.org/jira/browse/PROTON-1185
+					boolean shouldReportTimeout = false;
+					synchronized(MessageReceiver.this.flowSync)
+					{
+						shouldReportTimeout = (MessageReceiver.this.nextCreditToFlow == 0);
+					}
+					
+					if (shouldReportTimeout)
+						MessageReceiver.this.stuckTransportHandler.reportTimeoutError();
 				}
 			}
 		};
@@ -388,9 +399,9 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 			
 			return null;
 		}
-        catch (TimeoutException exception)
+        catch (java.util.concurrent.TimeoutException exception)
         {
-        	this.onError(new ServiceBusException(false, "Connection creation timed out.", exception));
+        	this.onError(new TimeoutException("Connection creation timed out.", exception));
         	return null;
         }
         
@@ -467,13 +478,13 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
         return receiver;
 	}
 	
+	// CONTRACT: message should be delivered to the caller of MessageReceiver.receive() only via Poll on prefetchqueue
 	private Message pollPrefetchQueue()
 	{
-		// message should be delivered only via Poll on prefetchqueue
-		// message lastReceivedOffset should be update upon each poll - as recreateLink will depend on this 
 		Message message = this.prefetchedMessages.poll();
 		if (message != null)
 		{
+			// message lastReceivedOffset should be up-to-date upon each poll - as recreateLink will depend on this 
 			this.lastReceivedOffset = message.getMessageAnnotations().getValue().get(AmqpConstants.OFFSET).toString();
 			this.sendFlow(1);
 		}
@@ -567,11 +578,9 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 					{
 						if (!linkOpen.getWork().isDone())
 						{
-							Exception cause = MessageReceiver.this.lastKnownLinkError;
-							Exception operationTimedout = new ServiceBusException(
-									cause != null && cause instanceof ServiceBusException ? ((ServiceBusException) cause).getIsTransient() : ClientConstants.DEFAULT_IS_TRANSIENT,
-									String.format(Locale.US, "ReceiveLink(%s) %s() on path(%s) timed out", MessageReceiver.this.receiveLink.getName(), "Open", MessageReceiver.this.receivePath),
-									cause);
+							Exception operationTimedout = new TimeoutException(
+									String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", MessageReceiver.this.receiveLink.getName(), MessageReceiver.this.receivePath, ZonedDateTime.now()),
+									MessageReceiver.this.lastKnownLinkError);
 							if (TRACE_LOGGER.isLoggable(Level.WARNING))
 							{
 								TRACE_LOGGER.log(Level.WARNING, 
@@ -599,7 +608,7 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 						{
 							if (!linkClose.isDone())
 							{
-								Exception operationTimedout = new TimeoutException(String.format(Locale.US, "Receive Link(%s) %s() timed out", MessageReceiver.this.receiveLink.getName(), "Close"));
+								Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", MessageReceiver.this.receiveLink.getName(), ZonedDateTime.now()));
 								if (TRACE_LOGGER.isLoggable(Level.WARNING))
 								{
 									TRACE_LOGGER.log(Level.WARNING, 

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -4,10 +4,25 @@
  */
 package com.microsoft.azure.servicebus;
 
-import com.microsoft.azure.servicebus.amqp.AmqpConstants;
-import com.microsoft.azure.servicebus.amqp.IAmqpSender;
-import com.microsoft.azure.servicebus.amqp.SendLinkHandler;
-import com.microsoft.azure.servicebus.amqp.SessionHandler;
+import java.nio.BufferOverflowException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
@@ -28,23 +43,10 @@ import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.engine.impl.DeliveryImpl;
 import org.apache.qpid.proton.message.Message;
 
-import java.nio.BufferOverflowException;
-import java.time.Duration;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.microsoft.azure.servicebus.amqp.AmqpConstants;
+import com.microsoft.azure.servicebus.amqp.IAmqpSender;
+import com.microsoft.azure.servicebus.amqp.SendLinkHandler;
+import com.microsoft.azure.servicebus.amqp.SessionHandler;
 
 /**
  * Abstracts all amqp related details
@@ -53,9 +55,10 @@ import java.util.logging.Logger;
 public class MessageSender extends ClientEntity implements IAmqpSender, IErrorContextProvider
 {
 	private static final Logger TRACE_LOGGER = Logger.getLogger(ClientConstants.SERVICEBUS_CLIENT_TRACE);
-	private static final String SEND_TIMED_OUT = "Send operation timed out.";
+	private static final String SEND_TIMED_OUT = "Send operation timed out";
 	
 	private final MessagingFactory underlyingFactory;
+	private final ITimeoutErrorHandler timeoutErrorHandler;
 	private final String sendPath;
 	private final Duration operationTimeout;
 	private final RetryPolicy retryPolicy;
@@ -73,6 +76,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 	private boolean linkCreateScheduled;
 	private Object linkCreateLock;
 	private Exception lastKnownLinkError;
+	private Instant lastKnownErrorReportedAt;
 	private Object sendCall;
 	
 	public static CompletableFuture<MessageSender> create(
@@ -80,7 +84,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 			final String sendLinkName,
 			final String senderPath)
 	{
-		final MessageSender msgSender = new MessageSender(factory, sendLinkName, senderPath);
+		final MessageSender msgSender = new MessageSender(factory, factory, sendLinkName, senderPath);
 		msgSender.openLinkTracker = TimeoutTracker.create(factory.getOperationTimeout());
 		msgSender.initializeLinkOpen(msgSender.openLinkTracker);
 		msgSender.linkCreateScheduled = true;
@@ -95,14 +99,16 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 		return msgSender.linkFirstOpen;
 	}
 	
-	private MessageSender(final MessagingFactory factory, final String sendLinkName, final String senderPath)
+	private MessageSender(final MessagingFactory factory, final ITimeoutErrorHandler timeoutErrorHandler, final String sendLinkName, final String senderPath)
 	{
 		super(sendLinkName);
 		this.sendPath = senderPath;
 		this.underlyingFactory = factory;
+		this.timeoutErrorHandler = timeoutErrorHandler;
 		this.operationTimeout = factory.getOperationTimeout();
 		this.timerTimeout = this.operationTimeout.getSeconds() > 9 ? this.operationTimeout.dividedBy(3) : Duration.ofSeconds(5);
 		this.lastKnownLinkError = null;
+		this.lastKnownErrorReportedAt = Instant.EPOCH;
 		
 		this.retryPolicy = factory.getRetryPolicy();
 		
@@ -192,12 +198,10 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 		byte[] tag = deliveryTag == null ? this.getNextDeliveryTag() : deliveryTag;
 		boolean messageSent = false;
 		
-		if (this.sendLink.getLocalState() == EndpointState.CLOSED)
-		{
-			this.scheduleRecreate(Duration.ofMillis(1));
-		}
-		else if (this.linkCredit.get() > 0 && 
-				(this.pendingSendsWaitingForCredit.isEmpty() || this.pendingSendsWaitingForCredit.peek() == deliveryTag))
+		if (this.sendLink != null 
+				&& this.sendLink.getLocalState() != EndpointState.CLOSED && this.sendLink.getRemoteState() != EndpointState.CLOSED
+				&& this.linkCredit.get() > 0 && !this.retryPolicy.isServerBusy()
+				&& (this.pendingSendsWaitingForCredit.isEmpty() || this.pendingSendsWaitingForCredit.peek() == deliveryTag))
         {
 			synchronized (this.sendCall)
 			{
@@ -366,9 +370,12 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 		if (completionException == null)
 		{
 			this.openLinkTracker = null;
+
+			this.lastKnownLinkError = null;
 			this.retryPolicy.resetRetryCount(this.getClientId());
 			
-			this.lastKnownLinkError = null;
+			// assumption here is that TimeoutErrorHandler reset's the link
+			this.timeoutErrorHandler.resetTimeoutErrorTracking();
 			
 			if (!this.linkFirstOpen.isDone())
 			{
@@ -428,6 +435,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 		if (completionException != null)
 		{
 			this.lastKnownLinkError = completionException;
+			this.lastKnownErrorReportedAt = Instant.now();
 		}
 		
 		if (retryInterval != null)
@@ -497,7 +505,9 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 			CompletableFuture<Void> pendingSend = pendingSendWorkItem.getWork();
 			if (outcome instanceof Accepted)
 			{
+				this.lastKnownLinkError = null;
 				this.retryPolicy.resetRetryCount(this.getClientId());
+				this.timeoutErrorHandler.resetTimeoutErrorTracking();
 				this.pendingSendWaiters.remove(deliveryTag);
 				pendingSend.complete(null);
 			}
@@ -507,6 +517,12 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 				ErrorCondition error = rejected.getError();
 				Exception exception = ExceptionUtil.toException(error);
 
+				if (ExceptionUtil.isGeneralSendError(error.getCondition()))
+				{
+					this.lastKnownLinkError = exception;
+					this.lastKnownErrorReportedAt = Instant.now();
+				}
+				
 				Duration retryInterval = this.retryPolicy.getNextRetryInterval(
 						this.getClientId(), exception, pendingSendWorkItem.getTimeoutTracker().remaining());
 				if (retryInterval == null)
@@ -573,9 +589,9 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 			
 			return null;
 		}
-		catch (TimeoutException exception)
+		catch (java.util.concurrent.TimeoutException exception)
         {
-        	this.onError(new ServiceBusException(false, "Connection creation timed out.", exception));
+        	this.onError(new TimeoutException("Connection creation timed out.", exception));
         	return null;
         }
 		
@@ -624,9 +640,9 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 					{
 						if (!MessageSender.this.linkFirstOpen.isDone())
 						{
-							Exception operationTimedout = new ServiceBusException(true,
-									String.format(Locale.US, "SendLink(%s).open() on Entity(%s) timed out",
-											MessageSender.this.sendLink.getName(), MessageSender.this.getSendPath()));
+							Exception operationTimedout = new TimeoutException(
+									String.format(Locale.US, "Open operation on SendLink(%s) on Entity(%s) timed out at %s.",	MessageSender.this.sendLink.getName(), MessageSender.this.getSendPath(), ZonedDateTime.now().toString()),
+									MessageSender.this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS)) ? MessageSender.this.lastKnownLinkError : null);
 
 							if (TRACE_LOGGER.isLoggable(Level.WARNING))
 							{
@@ -673,6 +689,9 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 	@Override
 	public void onFlow()
 	{
+		this.timeoutErrorHandler.resetTimeoutErrorTracking();
+		this.lastKnownLinkError = null;
+		
 		int updatedCredit = 0;
 		synchronized (this.sendCall)
 		{
@@ -701,10 +720,25 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 	
 	private void throwSenderTimeout(CompletableFuture<Void> pendingSendWork, Exception lastKnownException)
 	{
-		Exception cause = lastKnownException == null ? this.lastKnownLinkError : lastKnownException;
-		ServiceBusException exception = new ServiceBusException(
-				cause != null && cause instanceof ServiceBusException ? ((ServiceBusException) cause).getIsTransient() : ClientConstants.DEFAULT_IS_TRANSIENT, 
-				MessageSender.SEND_TIMED_OUT, cause);
+		Exception cause = lastKnownException;
+		if (lastKnownException == null && this.lastKnownLinkError != null)
+		{
+			boolean isServerBusy = ((this.lastKnownLinkError instanceof ServerBusyException) 
+					&& (this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS))));  
+			cause = isServerBusy || (this.lastKnownErrorReportedAt.isAfter(Instant.now().minusMillis(this.operationTimeout.toMillis()))) 
+					? this.lastKnownLinkError 
+					: null;
+		}
+				
+		boolean isClientSideTimeout = (cause == null || !(cause instanceof ServiceBusException));
+		ServiceBusException exception = isClientSideTimeout
+				? new TimeoutException(String.format(Locale.US, "%s %s %s.", MessageSender.SEND_TIMED_OUT, " at ", ZonedDateTime.now(), cause)) 
+				: (ServiceBusException) cause;
+		if (isClientSideTimeout)
+		{
+			this.timeoutErrorHandler.reportTimeoutError();
+		}
+		
 		ExceptionUtil.completeExceptionally(pendingSendWork, exception, this);
 	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ReplayableWorkItem.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ReplayableWorkItem.java
@@ -7,8 +7,6 @@ package com.microsoft.azure.servicebus;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.qpid.proton.message.Message;
-
 public class ReplayableWorkItem<T> extends WorkItem<T>
 {
 	private byte[] amqpMessage;

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/RetryExponential.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/RetryExponential.java
@@ -4,10 +4,10 @@
  */
 package com.microsoft.azure.servicebus;
 
-import java.time.*;
+import java.time.Duration;
 
 /**
- *  RetryPolicy implementation where the delay between retries will grow in a staggered exponential manner.
+ *  RetryPolicy implementation where the delay between retries will grow in an exponential manner.
  *  RetryPolicy can be set on the client operations using {@link ConnectionStringBuilder}.
  *  RetryIntervals will be computed using a retryFactor which is a function of deltaBackOff (MaximumBackoff - MinimumBackoff) and MaximumRetryCount
  */
@@ -27,7 +27,7 @@ public final class RetryExponential extends RetryPolicy
 	}
 
 	@Override
-	public Duration getNextRetryInterval(String clientId, Exception lastException, Duration remainingTime)
+	protected Duration onGetNextRetryInterval(String clientId, Exception lastException, Duration remainingTime)
 	{
 		int currentRetryCount = this.getRetryCount(clientId);
 	
@@ -41,7 +41,7 @@ public final class RetryExponential extends RetryPolicy
 		{
 			return null;
 		}
-	
+		
 		double nextRetryInterval = Math.pow(this.retryFactor, (double)currentRetryCount);
 		long nextRetryIntervalSeconds = (long) nextRetryInterval ;
 		long nextRetryIntervalNano = (long)((nextRetryInterval - (double)nextRetryIntervalSeconds) * 1000000000);
@@ -57,7 +57,8 @@ public final class RetryExponential extends RetryPolicy
 	private double computeRetryFactor()
 	{
 		long deltaBackoff = this.maximumBackoff.minus(this.minimumBackoff).getSeconds();
-		if (deltaBackoff <= 0 || this.maximumRetryCount <= 0) {
+		if (deltaBackoff <= 0 || this.maximumRetryCount <= 0)
+		{
 			return 0;
 		}
 		

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/TimeoutException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/TimeoutException.java
@@ -4,26 +4,26 @@
  */
 package com.microsoft.azure.servicebus;
 
-public class ServerBusyException extends ServiceBusException 
+public class TimeoutException extends ServiceBusException
 {
 	private static final long serialVersionUID = 1L;
 
-	public ServerBusyException()
+	public TimeoutException()
 	{
 		super(true);
 	}
 
-	ServerBusyException(final String message)
+	public TimeoutException(final String message)
 	{
 		super(true, message);
 	}
 
-	ServerBusyException(final Throwable cause)
+	public TimeoutException(final Throwable cause)
 	{
 		super(true, cause);
 	}
 
-	ServerBusyException(final String message, final Throwable cause)
+	public TimeoutException(final String message, final Throwable cause)
 	{
 		super(true, message, cause);
 	}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
@@ -5,12 +5,13 @@
 package com.microsoft.azure.servicebus.amqp;
 
 import java.util.Locale;
-import java.util.logging.*;
+import java.util.logging.Level;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.apache.qpid.proton.engine.*;
-
-import com.microsoft.azure.servicebus.*;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Sender;
 
 public class SendLinkHandler extends BaseLinkHandler
 {
@@ -62,10 +63,10 @@ public class SendLinkHandler extends BaseLinkHandler
     public void onDelivery(Event event)
 	{		
 		Delivery delivery = event.getDelivery();
-		Sender sender = (Sender) delivery.getLink();
 		if(TRACE_LOGGER.isLoggable(Level.FINEST))
         {
-            TRACE_LOGGER.log(Level.FINEST, 
+			Sender sender = (Sender) delivery.getLink();
+			TRACE_LOGGER.log(Level.FINEST, 
             		"linkName[" + sender.getName() + 
             		"], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getCredit()+ "], deliveryState[" + delivery.getRemoteState() + 
             		"], delivery.isBuffered[" + delivery.isBuffered() +"], delivery.id[" + delivery.getTag() + "]");
@@ -103,11 +104,8 @@ public class SendLinkHandler extends BaseLinkHandler
     public void onLinkRemoteClose(Event event)
 	{
 		Link link = event.getLink();
-        if (link instanceof Sender)
-        {
-        	ErrorCondition condition = link.getRemoteCondition();
-    		this.processOnClose(link, condition);
-        }
+    	ErrorCondition condition = link.getRemoteCondition();
+		this.processOnClose(link, condition);
 	}
 	
 	@Override

--- a/java/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/TimeoutExceptionTest.java
+++ b/java/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/TimeoutExceptionTest.java
@@ -1,7 +1,6 @@
 package com.microsoft.azure.eventhubs.exceptioncontracts;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.12.2</proton-j-version>
 	  	<junit-version>4.10</junit-version>
-		<client-current-version>0.6.9</client-current-version>
+		<client-current-version>0.6.10</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Surface correct Timeout Exceptions & fix bugs in Send OperationTimeout

Tracking Id & Timestamp on client generated exceptions (Connection Reset's & reactor Errors)

report timeout - only when the proton-j issue #1185 is encountered

filter old link level errors while throwing timeout errors

Synchronize connectionreset logic - to protect client from DOS when multiple senders are reporting timeouts on single MessagingFactory