### PR TITLE
Sender timeout issues

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -4,13 +4,23 @@
  */
 package com.microsoft.azure.eventhubs;
 
-import java.time.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.function.*;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.qpid.proton.message.Message;
-import com.microsoft.azure.servicebus.*;
+
+import com.microsoft.azure.servicebus.ClientEntity;
+import com.microsoft.azure.servicebus.MessageReceiver;
+import com.microsoft.azure.servicebus.MessagingFactory;
+import com.microsoft.azure.servicebus.ServiceBusException;
+import com.microsoft.azure.servicebus.StringUtil;
 
 /**
  * This is a logical representation of receiving from a EventHub partition.

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/AuthorizationFailedException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/AuthorizationFailedException.java
@@ -6,6 +6,8 @@ package com.microsoft.azure.servicebus;
 
 public class AuthorizationFailedException extends ServiceBusException
 {
+	private static final long serialVersionUID = 1L;
+
 	AuthorizationFailedException()
 	{
 		super(false);

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -42,4 +42,5 @@ public final class ClientConstants
 	public final static boolean DEFAULT_IS_TRANSIENT = true;
 	
 	public final static int REACTOR_IO_POLL_TIMEOUT = 20;
+	public final static int SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS = 10;
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
@@ -4,9 +4,17 @@
  */
 package com.microsoft.azure.servicebus;
 
-import java.util.concurrent.*;
-import org.apache.qpid.proton.amqp.transport.*;
-import com.microsoft.azure.servicebus.amqp.*;
+import java.time.ZonedDateTime;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+
+import com.microsoft.azure.servicebus.amqp.AmqpErrorCode;
+import com.microsoft.azure.servicebus.amqp.AmqpException;
 
 final class ExceptionUtil
 {
@@ -94,5 +102,18 @@ final class ExceptionUtil
 		}
 		
 		future.completeExceptionally(exception);
+	}
+	
+	// not a specific message related error
+	static boolean isGeneralSendError(Symbol amqpError)
+	{
+		return (amqpError == ClientConstants.SERVER_BUSY_ERROR 
+				|| amqpError == ClientConstants.TIMEOUT_ERROR 
+				|| amqpError == AmqpErrorCode.ResourceLimitExceeded);
+	}
+	
+	static String getTrackingIDAndTimeToLog()
+	{
+		return String.format(Locale.US, "TrackingId: %s, at: %s", UUID.randomUUID().toString(), ZonedDateTime.now()); 
 	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ITimeoutErrorHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ITimeoutErrorHandler.java
@@ -4,7 +4,10 @@
  */
 package com.microsoft.azure.servicebus;
 
-// recover client from the underlying TransportStack-Stuck situation
+// multiple issues were identified in the proton-j layer which could lead to a stuck state in Transport
+// https://issues.apache.org/jira/browse/PROTON-1185
+// https://issues.apache.org/jira/browse/PROTON-1171
+// This handler is built to - recover client from the underlying TransportStack-Stuck situation
 public interface ITimeoutErrorHandler
 {
 	public void reportTimeoutError();

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ReplayableWorkItem.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ReplayableWorkItem.java
@@ -7,8 +7,6 @@ package com.microsoft.azure.servicebus;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.qpid.proton.message.Message;
-
 public class ReplayableWorkItem<T> extends WorkItem<T>
 {
 	private byte[] amqpMessage;

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/TimeoutException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/TimeoutException.java
@@ -4,26 +4,26 @@
  */
 package com.microsoft.azure.servicebus;
 
-public class ServerBusyException extends ServiceBusException 
+public class TimeoutException extends ServiceBusException
 {
 	private static final long serialVersionUID = 1L;
 
-	public ServerBusyException()
+	public TimeoutException()
 	{
 		super(true);
 	}
 
-	ServerBusyException(final String message)
+	public TimeoutException(final String message)
 	{
 		super(true, message);
 	}
 
-	ServerBusyException(final Throwable cause)
+	public TimeoutException(final Throwable cause)
 	{
 		super(true, cause);
 	}
 
-	ServerBusyException(final String message, final Throwable cause)
+	public TimeoutException(final String message, final Throwable cause)
 	{
 		super(true, message, cause);
 	}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
@@ -5,12 +5,13 @@
 package com.microsoft.azure.servicebus.amqp;
 
 import java.util.Locale;
-import java.util.logging.*;
+import java.util.logging.Level;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.apache.qpid.proton.engine.*;
-
-import com.microsoft.azure.servicebus.*;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Sender;
 
 public class SendLinkHandler extends BaseLinkHandler
 {
@@ -62,10 +63,10 @@ public class SendLinkHandler extends BaseLinkHandler
     public void onDelivery(Event event)
 	{		
 		Delivery delivery = event.getDelivery();
-		Sender sender = (Sender) delivery.getLink();
 		if(TRACE_LOGGER.isLoggable(Level.FINEST))
         {
-            TRACE_LOGGER.log(Level.FINEST, 
+			Sender sender = (Sender) delivery.getLink();
+			TRACE_LOGGER.log(Level.FINEST, 
             		"linkName[" + sender.getName() + 
             		"], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getCredit()+ "], deliveryState[" + delivery.getRemoteState() + 
             		"], delivery.isBuffered[" + delivery.isBuffered() +"], delivery.id[" + delivery.getTag() + "]");
@@ -103,11 +104,8 @@ public class SendLinkHandler extends BaseLinkHandler
     public void onLinkRemoteClose(Event event)
 	{
 		Link link = event.getLink();
-        if (link instanceof Sender)
-        {
-        	ErrorCondition condition = link.getRemoteCondition();
-    		this.processOnClose(link, condition);
-        }
+    	ErrorCondition condition = link.getRemoteCondition();
+		this.processOnClose(link, condition);
 	}
 	
 	@Override

--- a/java/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/TimeoutExceptionTest.java
+++ b/java/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/TimeoutExceptionTest.java
@@ -1,7 +1,6 @@
 package com.microsoft.azure.eventhubs.exceptioncontracts;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.12.2</proton-j-version>
 	  	<junit-version>4.10</junit-version>
-		<client-current-version>0.6.9</client-current-version>
+		<client-current-version>0.6.10-SNAPSHOT</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Surface correct Timeout Exceptions & fix bugs in Send OperationTimeout

Tracking Id & Timestamp on client generated exceptions (Connection Reset's & reactor Errors)

report timeout - only when the proton-j issue #1185 is encountered

filter old link level errors while throwing timeout errors

minor refactor

Synchronize connectionreset logic - to protect client from DOS when multiple senders are reporting timeouts on single MessagingFactory

SendRetry's time should account for ServerBusyWaitTime=10sec. Fresh sends need not account for this - as we send events only when there is credit left on the Link.