### PR TITLE
remove connectionReset workaround on Timeout Errors

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -242,11 +242,6 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 		
 		if (!messageSent)
 		{
-			if (this.sendLink.getLocalState() == EndpointState.CLOSED || this.sendLink.getRemoteState() == EndpointState.CLOSED)
-			{
-				this.scheduleRecreate(Duration.ofSeconds(0));
-			}
-			
 			if (!this.pendingSendsWaitingForCredit.contains(tag))
 			{
 				if (onSend != null)

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessagingFactory.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessagingFactory.java
@@ -46,6 +46,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection, I
 	private final CompletableFuture<Void> closeTask;
 	private final ConnectionHandler connectionHandler;
 	private final ReactorHandler reactorHandler;
+	private final LinkedList<Link> registeredLinks;
 	
 	private Reactor reactor;
 	private Thread reactorThread;
@@ -56,7 +57,6 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection, I
 	private RetryPolicy retryPolicy;
 	private CompletableFuture<MessagingFactory> open;
 	private CompletableFuture<Connection> openConnection;
-	private LinkedList<Link> registeredLinks;
 	private TimeoutTracker connectionCreateTracker;
 	private Instant timeoutErrorStart;
 	private Object resetConnectionSync;

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/RetryExponential.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/RetryExponential.java
@@ -29,7 +29,7 @@ public final class RetryExponential extends RetryPolicy
 	}
 
 	@Override
-	protected Duration onGetNextRetryInterval(String clientId, Exception lastException, Duration remainingTime)
+	protected Duration onGetNextRetryInterval(final String clientId, final Exception lastException, final Duration remainingTime, final int baseWaitTimeSecs)
 	{
 		int currentRetryCount = this.getRetryCount(clientId);
 	
@@ -38,7 +38,6 @@ public final class RetryExponential extends RetryPolicy
 			return null;
 		}
 		
-		// keep track of last error and add extra wait for ServerBusyException
 		if (!RetryPolicy.isRetryableException(lastException))
 		{
 			return null;
@@ -53,8 +52,7 @@ public final class RetryExponential extends RetryPolicy
 		}
 		
 		Duration retryAfter = this.minimumBackoff.plus(Duration.ofSeconds(nextRetryIntervalSeconds, nextRetryIntervalNano));
-		if (this.isServerBusy())
-			retryAfter = retryAfter.plus(Duration.ofSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS));
+		retryAfter = retryAfter.plus(Duration.ofSeconds(baseWaitTimeSecs));
 
 		return retryAfter;
 	}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpSender.java
@@ -4,11 +4,11 @@
  */
 package com.microsoft.azure.servicebus.amqp;
 
-import org.apache.qpid.proton.amqp.transport.*;
+import org.apache.qpid.proton.engine.Delivery;
 
 public interface IAmqpSender extends IAmqpLink
 {
 	void onFlow();
 	
-	void onSendComplete(final byte[] deliveryTag, final DeliveryState outcome);
+	void onSendComplete(final Delivery delivery);
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorHandler.java
@@ -25,7 +25,7 @@ public class ReactorHandler extends BaseHandler
             TRACE_LOGGER.log(Level.FINE, "reactor.onReactorInit");
         }
 		
-		Reactor reactor = e.getReactor();
+		final Reactor reactor = e.getReactor();
 		reactor.setTimeout(ClientConstants.REACTOR_IO_POLL_TIMEOUT);
 	}
     

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/SendLinkHandler.java
@@ -72,8 +72,7 @@ public class SendLinkHandler extends BaseLinkHandler
             		"], delivery.isBuffered[" + delivery.isBuffered() +"], delivery.id[" + new String(delivery.getTag()) + "]");
         }
 		
-		msgSender.onSendComplete(delivery.getTag(), delivery.getRemoteState());
-		delivery.settle();
+		msgSender.onSendComplete(delivery);
 	}
 
 	@Override

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.12.2</proton-j-version>
 	  	<junit-version>4.10</junit-version>
-		<client-current-version>0.6.10-SNAPSHOT</client-current-version>
+		<client-current-version>0.6.12</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Improvements:

SendLink & RecvLink creation will always be reactive - based on Reactor Events
Normalize receive Traces
ServerBusyException contract changed: client will initiate sends although ServerBusy error is thrown - only upon error - it will slow down by 4 secs
Bump up the version to 0.6.12