### PR TITLE
JavaClient: Fix Receiver Stuck issues

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpReceiver.java
@@ -4,9 +4,10 @@
  */
 package com.microsoft.azure.servicebus.amqp;
 
+import org.apache.qpid.proton.engine.Delivery;
 import org.apache.qpid.proton.message.Message;
 
 public interface IAmqpReceiver extends IAmqpLink
 {
-	void onReceiveComplete(Message message);
+	void onReceiveComplete(Delivery delivery);
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
@@ -122,21 +122,8 @@ public final class ReceiveLinkHandler extends BaseLinkHandler
 		// all until "last-1" deliveries will be partial
 		// reactor will raise onDelivery event for all of these - we only need the last one
 		if (!delivery.isPartial())
-		{
-			// delivery.pending() should return current deliveries pending bytes to be read.
-			// we ran into an issue with proton-j where delivery.pending() returned lessthan available bytes and hence the below Math.max(...)
-			int msgSize = delivery.pending() + ClientConstants.MAX_FRAME_SIZE_BYTES;
-			byte[] buffer = new byte[msgSize];
-			int read = receiveLink.recv(buffer, 0, msgSize);
-
-			delivery.settle();
-
-			if (read != -1)
-			{
-				Message msg = Proton.message();
-				msg.decode(buffer, 0, read);
-				this.amqpReceiver.onReceiveComplete(msg);
-			}
+		{	
+			this.amqpReceiver.onReceiveComplete(delivery);
 		}
 
 		if(TRACE_LOGGER.isLoggable(Level.FINEST) && receiveLink != null)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.12.2</proton-j-version>
 	  	<junit-version>4.10</junit-version>
-		<client-current-version>0.7.0</client-current-version>
+		<client-current-version>0.7.1</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
Fix synchronization issue while sending the Flow

reset flow if link is recreated

Synchronize the calls manipulating the workqueue of proton ConnectionImpl

synchronize deserializing the amqp delivery

Fix NPE while deserializing the message in the MessageReceiver onReceive Callback