### PR TITLE
Bulk change pull

### DIFF
--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
@@ -56,7 +56,7 @@ class AzureBlobLease extends Lease
 	long getSequenceNumber() { return this.sequenceNumber; }
 
 	@Override
-	boolean isExpired() throws Exception
+	public boolean isExpired() throws Exception
 	{
 		this.blob.downloadAttributes(); // Get the latest metadata
 		LeaseState currentState = this.blob.getProperties().getLeaseState();

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Checkpoint.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Checkpoint.java
@@ -7,17 +7,38 @@ package com.microsoft.azure.eventprocessorhost;
 
 import com.microsoft.azure.eventhubs.PartitionReceiver;
 
+/**
+ * Checkpoint class is public so that advanced users can implement an ICheckpointManager. 
+ * Unless you are implementing ICheckpointManager you should not have to deal with objects
+ * of this class directly.
+ * <p>
+ * A Checkpoint is essentially just a tuple. It has a fixed partition id, set at creation time
+ * and immutable thereafter, and associates that with an offset/sequenceNumber pair which
+ * indicates a position within the messages in that partition.
+ */
 public class Checkpoint
 {
 	private final String partitionId;
 	private String offset = PartitionReceiver.START_OF_STREAM;
 	private long sequenceNumber = 0;
 	
+	/**
+	 * Create a checkpoint with offset/sequenceNumber set to the first available message.
+	 * 
+	 * @param partitionId
+	 */
 	public Checkpoint(String partitionId)
 	{
 		this.partitionId = partitionId;
 	}
 	
+	/**
+	 * Create a checkpoint with the given offset and sequenceNumber.
+	 * 
+	 * @param partitionId
+	 * @param offset
+	 * @param sequenceNumber
+	 */
 	public Checkpoint(String partitionId, String offset, long sequenceNumber)
 	{
 		this.partitionId = partitionId;
@@ -25,6 +46,11 @@ public class Checkpoint
 		this.sequenceNumber = sequenceNumber;
 	}
 	
+	/**
+	 * Create a checkpoint which is a duplicate of the given checkpoint.
+	 * 
+	 * @param source
+	 */
 	public Checkpoint(Checkpoint source)
 	{
 		this.partitionId = source.partitionId;
@@ -32,26 +58,53 @@ public class Checkpoint
 		this.sequenceNumber = source.sequenceNumber;
 	}
 	
+	/**
+	 * Set the offset. Should be paired with setSequenceNumber since the two values are
+	 * connected in the Event Hub.
+	 * 
+	 * @param newOffset
+	 */
 	public void setOffset(String newOffset)
 	{
 		this.offset = newOffset;
 	}
-	
+
+	/**
+	 * Return the offset.
+	 * 
+	 * @return
+	 */
 	public String getOffset()
 	{
 		return this.offset;
 	}
 	
+	/**
+	 * Set the sequence number. Should be paired with setOffset since the two values are
+	 * connected in the Event Hub.
+	 * 
+	 * @param newSequenceNumber
+	 */
 	public void setSequenceNumber(long newSequenceNumber)
 	{
 		this.sequenceNumber = newSequenceNumber;
 	}
 	
+	/**
+	 * Get the sequence number.
+	 * 
+	 * @return
+	 */
 	public long getSequenceNumber()
 	{
 		return this.sequenceNumber;
 	}
 	
+	/**
+	 * Get the partition id. There is no corresponding setter because the partition id is immutable.
+	 * 
+	 * @return
+	 */
 	public String getPartitionId()
 	{
 		return this.partitionId;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
@@ -5,7 +5,22 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-class Lease
+/**
+ * Lease class is public so that advanced users can implement an ILeaseManager. 
+ * Unless you are implementing ILeaseManager you should not have to deal with objects
+ * of this class or derived classes directly.
+ * <p>
+ * When implementing an ILeaseManager it may be necessary to derive from this class to
+ * carry around more information and override isExpired. The data fields have been left
+ * private instead of protected because they have a full set of getters and setters
+ * (except partitionId, which is immutable) which provide equivalent access. When
+ * implementing AzureBlobLease, for example, there was no need for more access than
+ * the getters and setters provide.
+ * <p>
+ * Note that a Lease object just carries information about a partition lease. The functionality
+ * to acquire/renew/release a lease is all on the ILeaseManager.
+ */
+public class Lease
 {
     private final String partitionId;
 
@@ -13,7 +28,12 @@ class Lease
     private String owner;
     private String token;
 
-    Lease(String partitionId)
+    /**
+     * Create a Lease for the given partition.
+     * 
+     * @param partitionId
+     */
+    public Lease(String partitionId)
     {
         this.partitionId = partitionId;
 
@@ -22,7 +42,12 @@ class Lease
         this.token = "";
     }
 
-    Lease(Lease source)
+    /**
+     * Create a Lease by duplicating the given Lease.
+     * 
+     * @param source
+     */
+    public Lease(Lease source)
     {
         this.partitionId = source.partitionId;
 
@@ -31,48 +56,101 @@ class Lease
         this.token = source.token;
     }
 
-    long getEpoch()
+    /**
+     * Epoch is a concept used by Event Hub receivers. Basically, if a receiver is created on a partition
+     * with a higher epoch than the existing receiver, the previous receiver is forcibly disconnected.
+     * Attempting to create a receiver with a lower epoch that the existing receiver will fail. The Lease
+     * carries the epoch around so that when a host steals a lease, it can create a receiver with a higher epoch.
+     *  
+     * @return
+     */
+    public long getEpoch()
     {
         return this.epoch;
     }
 
-    void setEpoch(long epoch)
+    /**
+     * Set the epoch value.
+     * 
+     * @param epoch
+     */
+    public void setEpoch(long epoch)
     {
         this.epoch = epoch;
     }
     
-    long incrementEpoch()
+    /**
+     * The most common operation on the epoch value is incrementing it after stealing a lease. This
+     * convenience function replaces the get-increment-set that would otherwise be required.
+     * 
+     * @return The new value of the epoch.
+     */
+    public long incrementEpoch()
     {
     	this.epoch++;
     	return this.epoch;
     }
     
-    String getOwner()
+    /**
+     * The owner of a lease is the name of the EventProcessorHost which currently holds the lease.
+     * 
+     * @return
+     */
+    public String getOwner()
     {
         return this.owner;
     }
 
-    void setOwner(String owner)
+    /**
+     * Set the owner string. Used when a host steals a lease.
+     * 
+     * @param owner
+     */
+    public void setOwner(String owner)
     {
         this.owner = owner;
     }
 
-    String getPartitionId()
+    /**
+     * Returns the id of the partition that this Lease is for. Immutable so there is no corresponding setter.
+     * 
+     * @return
+     */
+    public String getPartitionId()
     {
         return this.partitionId;
     }
 
-    String getToken()
+    /**
+     * The Lease carries an arbitrary string called the "token". AzureStorageCheckpointLeaseManager uses this to
+     * store the blob lease ID used by the Azure Storage API. Other implementations of ILeaseManager may use it
+     * for anything.
+     * 
+     * @return
+     */
+    public String getToken()
     {
         return this.token;
     }
 
-    void setToken(String token)
+    /**
+     * Set the token value.
+     * 
+     * @param token
+     */
+    public void setToken(String token)
     {
         this.token = token;
     }
 
-    boolean isExpired() throws Exception
+    /**
+     * If an implementation of ILeaseManager supports the concept of lease expiration, then a class derived from Lease
+     * may override this function to inspect the lease and return whether it has expired.
+     *  
+     * @return true if the lease is expired, false if it is still valid
+     * @throws Exception An override which does significant work may need to throw exceptions.
+     */
+    public boolean isExpired() throws Exception
     {
     	// this function is meaningless in the base class
     	return false;

--- a/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/event-processor-host/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -44,6 +44,11 @@ public class PartitionContext
     {
         return this.eventHubPath;
     }
+    
+    public String getOwner()
+    {
+    	return this.lease.getOwner();
+    }
 
     Lease getLease()
     {

--- a/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/CheckpointManagerTest.java
+++ b/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/CheckpointManagerTest.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.util.UUID;
+import java.util.concurrent.Future;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -10,9 +11,9 @@ public class CheckpointManagerTest
 	//
 	// Setup variables.
 	//
-	private boolean useAzureStorage = false; // false tests InMemoryCheckpointManager, true tests AzureStorageCheckpointLeaseManager
-	private String azureStorageConnectionString = ""; // must be set to valid connection string to test AzureStorageCheckpointLeaseManager
-	private int partitionCount = 4;
+	private boolean useAzureStorage = true; // false tests InMemoryCheckpointManager, true tests AzureStorageCheckpointLeaseManager
+	private String azureStorageConnectionString = TestUtilities.getStorageConnectionString(); // EPHTESTSTORAGE environment var must be set to valid connection string to test AzureStorageCheckpointLeaseManager
+	private int partitionCount = 64;
 	
 	private ILeaseManager[] leaseManagers;
 	private ICheckpointManager[] checkpointManagers;
@@ -184,6 +185,143 @@ public class CheckpointManagerTest
 		assertTrue("failed while cleaning up store", boolret);
 		
 		System.out.println("twoManagerCheckpointSmokeTest DONE");
+	}
+
+	
+	// Created while trying to find a possible handle leak when checkpointing.
+	// Not for general testing use.
+	//@Test
+	public void checkpointBrutalityTest() throws Exception
+	{
+		EventProcessorHost.setSkipExecutorShutdown(true);
+
+		final int checkpointers = 4;
+		this.leaseManagers = new ILeaseManager[checkpointers];
+		this.checkpointManagers = new ICheckpointManager[checkpointers];
+		this.hosts = new EventProcessorHost[checkpointers];
+		String containerName = generateContainerName(null);
+		for (int i = 0; i < checkpointers; i++)
+		{
+			setupOneManager(i, "brutality", containerName);
+		}
+		
+		System.out.println("checkpointBrutalityTest");
+		System.out.println("USING " + (useAzureStorage ? "AzureStorageCheckpointLeaseManager" : "InMemoryLeaseManager"));
+		
+		boolean boolret = this.checkpointManagers[0].createCheckpointStoreIfNotExists().get();
+		assertTrue("creating checkpoint store returned false", boolret);
+
+		boolret = this.checkpointManagers[0].checkpointStoreExists().get();
+		assertTrue("checkpoint store should exist but does not", boolret);
+		
+		Checkpoint[] checkpoints = new Checkpoint[this.partitionCount];
+		for (int i = 0; i < this.partitionCount; i++)
+		{
+			Checkpoint createdCheckpoint = this.checkpointManagers[0].createCheckpointIfNotExists(String.valueOf(i)).get();
+			checkpoints[i] = createdCheckpoint;
+			assertNotNull("failed creating checkpoint for " + i, createdCheckpoint);
+		}
+		
+		for (int i = 0; i < this.partitionCount; i++)
+		{
+			Checkpoint blah = this.checkpointManagers[0].getCheckpoint(String.valueOf(i)).get();
+			assertNotNull("failed to retrieve checkpoint for " + i, blah);
+		}
+		
+		// AzureStorageCheckpointLeaseManager tries to pretend that checkpoints and leases are separate, but they really aren't.
+		// Because the checkpoint data is stored in the lease, updating the checkpoint means updating the lease, and it is
+		// necessary to hold the lease in order to update it. Updating it renews the lease, so we don't have to worry about that.
+		if (this.useAzureStorage)
+		{
+			for (int i = 0; i < this.partitionCount; i++)
+			{
+				Lease l = this.leaseManagers[i % checkpointers].getLease(String.valueOf(i)).get();
+				assertNotNull("failed to retrieve lease for " + i, l);
+				boolret = this.leaseManagers[i % checkpointers].acquireLease(l).get();
+				assertTrue("failed to acquire lease for " + i, boolret);
+			}
+		}
+		
+		PartitionContext[] contexts = new PartitionContext[this.partitionCount];
+		for (int i = 0; i < this.partitionCount; i++)
+		{
+			contexts[i] = new PartitionContext(this.hosts[i % checkpointers], String.valueOf(i), "not used", "not used");
+		}
+		
+		for (int i = 0; i < checkpointers; i++)
+		{
+			final int iter = i; // allows handing current value of i to lambda
+			EventProcessorHost.getExecutorService().submit(() -> 
+			{
+				while (true)
+				{
+					for (int j = iter; j < this.partitionCount; j += checkpointers)
+					{
+						long newSeq = checkpoints[j].getSequenceNumber() + 1;
+						checkpoints[j].setOffset(String.valueOf(newSeq));
+						checkpoints[j].setSequenceNumber(newSeq);
+						
+						// Pick one: either update the checkpoints directly through the checkpoint manager, or
+						// do the read-modify-write cycle via PartitionContext.
+						
+						//this.checkpointManagers[iter].updateCheckpoint(checkpoints[j]);
+						contexts[j].setOffsetAndSequenceNumber(checkpoints[j].getOffset(), newSeq); contexts[j].checkpoint();
+						
+						incrementPerSecondCount();
+						if ((newSeq % 100) == 0)
+						{
+							System.out.println("Iter " + iter + " part " + j + " seq " + newSeq);
+						}
+						Thread.sleep(5);
+					}
+				}
+			});
+		}
+		EventProcessorHost.getExecutorService().submit(() ->
+		{
+			while (true)
+			{
+				try {
+					Thread.sleep(1000);
+				} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				System.out.println("******************* total per second ish " + returnAndClearPerSecondCount());
+			}
+		}).get(); // this get will never return
+
+		/* UNREACHABLE 
+		if (this.useAzureStorage)
+		{
+			for (int i = 0; i < this.partitionCount; i++)
+			{
+				Lease l = this.leaseManagers[0].getLease(String.valueOf(i)).get();
+				assertNotNull("failed to retrieve lease for " + i, l);
+				boolret = this.leaseManagers[0].releaseLease(l).get();
+				assertTrue("failed to acquire lease for " + i, boolret);
+			}
+		}
+		
+		boolret = this.checkpointManagers[0].deleteCheckpointStore().get();
+		assertTrue("failed while cleaning up store", boolret);
+		
+		System.out.println("checkpointBrutalityTest DONE");
+		*/
+	}
+	
+	int perSecondCount = 0;
+	
+	synchronized void incrementPerSecondCount()
+	{
+		this.perSecondCount++;
+	}
+	
+	synchronized int returnAndClearPerSecondCount()
+	{
+		int retval = this.perSecondCount;
+		this.perSecondCount = 0;
+		return retval;
 	}
 	
 	private String generateContainerName(String infix)

--- a/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
+++ b/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
@@ -440,7 +440,7 @@ public class InMemoryLeaseManager implements ILeaseManager
 		}
 		
 		@Override
-	    boolean isExpired() throws Exception
+	    public boolean isExpired() throws Exception
 	    {
 			boolean hasExpired = (System.currentTimeMillis() >= this.expirationTimeMillis);
 			if (hasExpired)

--- a/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/LeaseManagerTest.java
+++ b/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/LeaseManagerTest.java
@@ -11,7 +11,7 @@ public class LeaseManagerTest
 	// Setup variables.
 	//
 	private boolean useAzureStorage = true; // false tests InMemoryLeaseManager, true tests AzureStorageCheckpointLeaseManager
-	private String azureStorageConnectionString = ""; // must be set to valid connection string to test AzureStorageCheckpointLeaseManager
+	private String azureStorageConnectionString = TestUtilities.getStorageConnectionString(); // EPHTESTSTORAGE environment variable must be set to valid connection string to test AzureStorageCheckpointLeaseManager
 	private int partitionCount = 4;
 	
 	private ILeaseManager[] leaseManagers;

--- a/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
+++ b/java/event-processor-host/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
@@ -1,0 +1,10 @@
+package com.microsoft.azure.eventprocessorhost;
+
+class TestUtilities
+{
+	static String getStorageConnectionString()
+	{
+		String retval = System.getenv("EPHTESTSTORAGE");
+		return ((retval != null) ? retval : "");
+	}
+}


### PR DESCRIPTION
Added PartitionContext.getOwner so processor can identity owning host.
Thread-safe UUID generation.
Improve logging on error from storage.
New lease manager test: more hosts than partitions
New checkpoint test code trying to find a leak when checkpointing
Tests get storage connection string via environment variable.
Make Lease public for implementors of ILeaseManager.
JavaDoc Checkpoint and Lease
Make isExpired public in classes derived from Lease because it's public in Lease now.
 
