### PR TITLE
Cumulative pull from javaEPH2

### DIFF
--- a/java/azure-eventhubs-eph/Readme.md
+++ b/java/azure-eventhubs-eph/Readme.md
@@ -25,8 +25,11 @@ not present in that lower layer:
 
 ##Getting Started
 
-This library will be available from the Maven Central Repository and the other usual places. For now, it's just code in the
-main branch.
+This library is available from the Maven Central Repository. See the readme for the Java Azure Event Hubs client for more information.
+
+Note that Event Processor Host currently requires the Manage claim for the event hub in order to get the list of partition ids.
+We are aware that this additional permission requirement is undesirable and will have a change soon that will allow Event Processor
+Host to work with just the Listen claim.
 
 ##Using Event Processor Host
 

--- a/java/azure-eventhubs-eph/Readme.md
+++ b/java/azure-eventhubs-eph/Readme.md
@@ -144,7 +144,7 @@ Waiting for the Future to complete (by calling get) is important because initial
 ExecutionException from the get call. The actual failure is available as the inner exception on the ExecutionException.
 
     ``` Java
-    EventProcessorOptions options = new EventProcessorOptions();
+    EventProcessorOptions options = EventProcessorOptions.getDefaultOptions();
     options.setExceptionNotification(new ErrorNotificationHandler());
     try
     {

--- a/java/azure-eventhubs-eph/Readme.md
+++ b/java/azure-eventhubs-eph/Readme.md
@@ -27,10 +27,6 @@ not present in that lower layer:
 
 This library is available from the Maven Central Repository. See the readme for the Java Azure Event Hubs client for more information.
 
-Note that Event Processor Host currently requires the Manage claim for the event hub in order to get the list of partition ids.
-We are aware that this additional permission requirement is undesirable and will have a change soon that will allow Event Processor
-Host to work with just the Listen claim.
-
 ##Using Event Processor Host
 
 ###Step 1: Implement IEventProcessor

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureBlobLease.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import com.microsoft.azure.eventhubs.PartitionReceiver;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobProperties;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
@@ -14,7 +13,7 @@ import com.microsoft.azure.storage.blob.LeaseState;
 class AzureBlobLease extends Lease
 {
 	private transient CloudBlockBlob blob; // do not serialize
-	private String offset = PartitionReceiver.START_OF_STREAM;
+	private String offset = null; // null means checkpoint is uninitialized
 	private long sequenceNumber = 0;
 	
 	AzureBlobLease(String partitionId, CloudBlockBlob blob)

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -112,7 +112,15 @@ class EventHubPartitionPump extends PartitionPump
     	}
     	// else getInitialOffset threw an exception and we never get here
 		this.lease.setEpoch(epoch);
-		this.partitionReceiver = (PartitionReceiver) this.internalOperationFuture.get();
+		if (this.internalOperationFuture != null)
+		{
+			this.partitionReceiver = (PartitionReceiver) this.internalOperationFuture.get();
+		}
+		else
+		{
+			this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, "createEpochReceiver failed with null");
+			throw new RuntimeException("createEpochReceiver failed with null");
+		}
 		this.partitionReceiver.setPrefetchCount(this.host.getEventProcessorOptions().getPrefetchCount());
 		this.partitionReceiver.setReceiveTimeout(this.host.getEventProcessorOptions().getReceiveTimeOut());
 		this.internalOperationFuture = null;

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -110,7 +110,12 @@ class EventHubPartitionPump extends PartitionPump
     		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(),
     				(Instant)startAt, epoch);
     	}
-    	// else getInitialOffset threw an exception and we never get here
+    	else
+    	{
+    		String errMsg = "Starting offset is not String or Instant, is " + ((startAt != null) ? startAt.getClass().toString() : "null");
+    		this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, errMsg);
+    		throw new RuntimeException(errMsg);
+    	}
 		this.lease.setEpoch(epoch);
 		if (this.internalOperationFuture != null)
 		{

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -486,8 +486,7 @@ public final class EventProcessorHost
      * Synchronized string UUID generation convenience method.
      * 
      * We saw null and empty strings returned from UUID.randomUUID().toString() when used from multiple
-     * threads and there is no clear answer on the net about whether it is really thread-safe or not. Synchronizing
-     * on a static object has made the problem go away.
+     * threads and there is no clear answer on the net about whether it is really thread-safe or not.
      * <p>
      * One of the major users of UUIDs is the built-in lease and checkpoint manager, which can be replaced by
      * user implementations. This UUID generation method is public so user implementations can use it as well and
@@ -497,11 +496,10 @@ public final class EventProcessorHost
      */
     public static String safeCreateUUID()
     {
-    	String uuid = "not generated";
     	synchronized (EventProcessorHost.uuidSynchronizer)
     	{
-    		uuid = UUID.randomUUID().toString();
+    		final String uuid = UUID.randomUUID().toString();
+        	return uuid;
     	}
-    	return uuid;
     }
 }

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -18,8 +18,7 @@ public final class EventProcessorOptions
     private int maxBatchSize = 10;
     private int prefetchCount = 300;
     private Duration receiveTimeOut = Duration.ofMinutes(1);
-    private Function<String, Object> initialOffsetProvider =
-    		new Function<String, Object>() { @Override public Object apply(String blah) { return PartitionReceiver.START_OF_STREAM; }};
+    private Function<String, Object> initialOffsetProvider = (partitionId) -> { return PartitionReceiver.START_OF_STREAM; };
 
     /***
      * Returns an EventProcessorOptions instance with all options set to the default values.
@@ -122,11 +121,8 @@ public final class EventProcessorOptions
     }
 
     /***
-     * Returns the current function used to determine the initial offset at which to start receiving
-     * events for a partition.
-     * 
-     * A null return indicates that it is using the internal provider, which uses the last checkpointed
-     * offset value (if present) or START_OF_STREAM (if not).
+     * If there is no checkpoint for a partition, the initialOffsetProvider function is used to determine
+     * the offset at which to start receiving events for that partition.
      * 
      * @return the current offset provider function
      */
@@ -136,11 +132,11 @@ public final class EventProcessorOptions
     }
     
     /***
-     * Sets the function used to determine the initial offset at which to start receiving events for a
-     * partition when the EventProcessorHost obtains a new partition.
+     * Sets the function used to determine the offset at which to start receiving events for a
+     * partition if there is no checkpoint for that partition.
      * 
-     * The provider function takes one argument, the partition id (a string), and returns the desired
-     * starting offset (also a string).
+     * The provider function takes one argument, the partition id (a String), and returns either the desired
+     * starting offset (also a String) or the desired starting timestamp (an Instant).
      * 
      * @param initialOffsetProvider
      */

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -9,6 +9,8 @@ import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.microsoft.azure.eventhubs.PartitionReceiver;
+
 public final class EventProcessorOptions
 {
 	private Consumer<ExceptionReceivedEventArgs> exceptionNotificationHandler = null;
@@ -16,7 +18,8 @@ public final class EventProcessorOptions
     private int maxBatchSize = 10;
     private int prefetchCount = 300;
     private Duration receiveTimeOut = Duration.ofMinutes(1);
-    private Function<String, String> initialOffsetProvider = null;
+    private Function<String, Object> initialOffsetProvider =
+    		new Function<String, Object>() { @Override public Object apply(String blah) { return PartitionReceiver.START_OF_STREAM; }};
 
     /***
      * Returns an EventProcessorOptions instance with all options set to the default values.
@@ -127,7 +130,7 @@ public final class EventProcessorOptions
      * 
      * @return the current offset provider function
      */
-    public Function<String, String> getInitialOffsetProvider()
+    public Function<String, Object> getInitialOffsetProvider()
     {
     	return this.initialOffsetProvider;
     }
@@ -141,7 +144,7 @@ public final class EventProcessorOptions
      * 
      * @param initialOffsetProvider
      */
-    public void setInitialOffsetProvider(Function<String, String> initialOffsetProvider)
+    public void setInitialOffsetProvider(Function<String, Object> initialOffsetProvider)
     {
     	this.initialOffsetProvider = initialOffsetProvider;
     }

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -192,8 +192,12 @@ public class PartitionContext
     			persistThis.getOffset() + "//" + persistThis.getSequenceNumber());
 		
     	Checkpoint inStoreCheckpoint = this.host.getCheckpointManager().getCheckpoint(persistThis.getPartitionId()).get();
-    	if (persistThis.getSequenceNumber() >= inStoreCheckpoint.getSequenceNumber())
+    	if ((inStoreCheckpoint == null) || (persistThis.getSequenceNumber() >= inStoreCheckpoint.getSequenceNumber()))
     	{
+        	if (inStoreCheckpoint == null)
+        	{
+        		inStoreCheckpoint = this.host.getCheckpointManager().createCheckpointIfNotExists(persistThis.getPartitionId()).get();
+        	}
 	    	inStoreCheckpoint.setOffset(persistThis.getOffset());
 	    	inStoreCheckpoint.setSequenceNumber(persistThis.getSequenceNumber());
 	        this.host.getCheckpointManager().updateCheckpoint(inStoreCheckpoint).get();

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -110,12 +110,13 @@ public class PartitionContext
     	return this.partitionId;
     }
     
+    // Returns a String (offset) or Instant (timestamp).
     Object getInitialOffset() throws InterruptedException, ExecutionException
     {
     	Object startAt = null;
     	
     	Checkpoint startingCheckpoint = this.host.getCheckpointManager().getCheckpoint(this.partitionId).get();
-    	if (startingCheckpoint.getOffset() == null)
+    	if (startingCheckpoint == null)
     	{
     		// No checkpoint was ever stored. Use the initialOffsetProvider instead.
         	Function<String, Object> initialOffsetProvider = this.host.getEventProcessorOptions().getInitialOffsetProvider();

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -142,6 +142,7 @@ public class PartitionContext
     	{
     		// Checkpoint is valid, use it.
 	    	this.offset = startingCheckpoint.getOffset();
+	    	startAt = this.offset;
 	    	this.sequenceNumber = startingCheckpoint.getSequenceNumber();
 	    	this.host.logWithHostAndPartition(Level.FINE, this.partitionId, "Retrieved starting offset " + this.offset + "//" + this.sequenceNumber);
     	}

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -392,7 +392,11 @@ class PartitionManager
             	}
             	else
             	{
-            		this.pump.removePump(partitionId, CloseReason.LeaseLost);
+            		Future<?> removing = this.pump.removePump(partitionId, CloseReason.LeaseLost);
+            		if (removing != null)
+            		{
+            			removing.get();
+            		}
             	}
             }
             

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -33,6 +33,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -59,6 +60,8 @@ class PartitionManager
     {
         if (this.partitionIds == null)
         {
+        	this.partitionIds = new ArrayList<String>();
+        	
         	try
         	{
 	        	String contentEncoding = StandardCharsets.UTF_8.name();

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -32,8 +32,12 @@ class Pump
     		// There already is a pump. Make sure the pump is working and replace the lease.
     		if ((capturedPump.getPumpStatus() == PartitionPumpStatus.PP_ERRORED) || capturedPump.isClosing())
     		{
-    			// The existing pump is bad. Remove it and create a new one.
-    			removePump(partitionId, CloseReason.Shutdown).get();
+    			// The existing pump is bad. Remove it (if it exists!) and create a new one.
+    			Future<?> removing = removePump(partitionId, CloseReason.Shutdown);
+    			if (removing != null)
+    			{
+    				removing.get();
+    			}
     			createNewPump(partitionId, lease);
     		}
     		else


### PR DESCRIPTION
Fix NPE in new getPartitionIds.
Fix for null or empty UUIDs.
Multiple checkpoint-related fixes.
Readme updates.
Fix initialOffsetProvider to have correct semantics, and handle timestamp as well as offset.
Other fixes made while investigating possible memory leak.