### PR TITLE
reliability improvements

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -183,7 +183,7 @@ public final class PartitionReceiver extends ClientEntity
 	 * Set the number of events that can be pre-fetched and cached at the {@link PartitionReceiver}.
 	 * <p>By default the value is 300
 	 * @param prefetchCount the number of events to pre-fetch. value must be between 10 and 999. Default is 300.
-	 * @throws ServiceBusException 
+	 * @throws ServiceBusException if setting prefetchCount encounters error
 	 */
 	public final void setPrefetchCount(final int prefetchCount) throws ServiceBusException
 	{

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -61,7 +61,8 @@ public final class PartitionSender extends ClientEntity
 	/**
 	 * Synchronous version of {@link #send(EventData)} Api. 
 	 * @param data the {@link EventData} to be sent.
-	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @throws PayloadSizeExceededException    if the total size of the {@link EventData} exceeds a pre-defined limit set by the service. Default is 256k bytes.
+	 * @throws ServiceBusException             if Service Bus service encountered problems during the operation.
 	 */
 	public final void sendSync(final EventData data) 
 			throws ServiceBusException
@@ -115,8 +116,6 @@ public final class PartitionSender extends ClientEntity
 	 * 
 	 * @param data the {@link EventData} to be sent.
 	 * @return     a CompletableFuture that can be completed when the send operations is done..
-	 * @throws PayloadSizeExceededException    if the total size of the {@link EventData} exceeds a pre-defined limit set by the service. Default is 256k bytes.
-	 * @throws ServiceBusException             if Service Bus service encountered problems during the operation.
 	 */
 	public final CompletableFuture<Void> send(EventData data)
 	{

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -306,6 +306,8 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 					else
 						pendingReceives.offer(new ReceiveWorkItem(onReceive, receiveTimeout, maxMessageCount));
 
+					// calls to reactor should precede enqueue of the workItem into PendingReceives.
+					// This will allow error handling to enact on the enqueued workItem.
 					if (receiveLink.getLocalState() == EndpointState.CLOSED || receiveLink.getRemoteState() == EndpointState.CLOSED)
 					{
 						createReceiveLink();

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -300,16 +300,16 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 				@Override
 				public void onEvent()
 				{
-					if (receiveLink.getLocalState() == EndpointState.CLOSED || receiveLink.getRemoteState() == EndpointState.CLOSED)
-					{
-						createReceiveLink();
-					}
-
 					final List<Message> messages = receiveCore(maxMessageCount);
 					if (messages != null)
 						onReceive.complete(messages);
 					else
 						pendingReceives.offer(new ReceiveWorkItem(onReceive, receiveTimeout, maxMessageCount));
+
+					if (receiveLink.getLocalState() == EndpointState.CLOSED || receiveLink.getRemoteState() == EndpointState.CLOSED)
+					{
+						createReceiveLink();
+					}
 				}
 			});
 		}
@@ -422,42 +422,37 @@ public class MessageReceiver extends ClientEntity implements IAmqpReceiver, IErr
 			this.lastKnownLinkError = exception;
 			this.onOpenComplete(exception);
 			
-			if (exception != null &&
-					(!(exception instanceof ServiceBusException) || !((ServiceBusException) exception).getIsTransient()))
+			final WorkItem<Collection<Message>> workItem = this.pendingReceives.peek();
+			final Duration nextRetryInterval = workItem != null && workItem.getTimeoutTracker() != null
+					? this.underlyingFactory.getRetryPolicy().getNextRetryInterval(this.getClientId(), exception, workItem.getTimeoutTracker().remaining())
+					: null;
+			if (nextRetryInterval != null)
 			{
-				WorkItem<Collection<Message>> workItem = null;
-				while ((workItem = this.pendingReceives.poll()) != null)
+				try
 				{
-					ExceptionUtil.completeExceptionally(workItem.getWork(), exception, this);
+					this.underlyingFactory.scheduleOnReactorThread((int) nextRetryInterval.toMillis(), new DispatchHandler()
+					{
+						@Override
+						public void onEvent()
+						{
+							if (receiveLink.getLocalState() == EndpointState.CLOSED || receiveLink.getRemoteState() == EndpointState.CLOSED)
+							{
+								createReceiveLink();
+								underlyingFactory.getRetryPolicy().incrementRetryCount(getClientId());
+							}
+						}
+					});
+				}
+				catch (IOException ignore)
+				{
 				}
 			}
 			else
 			{
-				WorkItem<Collection<Message>> workItem = this.pendingReceives.peek();
-				if (workItem != null && workItem.getTimeoutTracker() != null)
+				WorkItem<Collection<Message>> pendingReceive = null;
+				while ((pendingReceive = this.pendingReceives.poll()) != null)
 				{
-					Duration nextRetryInterval = this.underlyingFactory.getRetryPolicy()
-							.getNextRetryInterval(this.getClientId(), exception, workItem.getTimeoutTracker().remaining());
-					if (nextRetryInterval != null)
-					{
-						try
-						{
-							this.underlyingFactory.scheduleOnReactorThread((int) nextRetryInterval.toMillis(), new DispatchHandler()
-							{
-								@Override
-								public void onEvent()
-								{
-									if (receiveLink.getLocalState() == EndpointState.CLOSED || receiveLink.getRemoteState() == EndpointState.CLOSED)
-									{
-										createReceiveLink();
-									}
-								}
-							});
-						}
-						catch (IOException ignore)
-						{
-						}
-					}
+					ExceptionUtil.completeExceptionally(pendingReceive.getWork(), exception, this);
 				}
 			}
 		}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -465,7 +465,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 								{
 									if (sendLink.getLocalState() == EndpointState.CLOSED || sendLink.getRemoteState() == EndpointState.CLOSED)
 									{
-										createSendLink();
+										recreateSendLink();
 									}
 								}
 							});
@@ -705,7 +705,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 	private void recreateSendLink()
 	{
 		this.createSendLink();
-		this.retryPolicy.incrementRetryCount(MessageSender.this.getClientId());
+		this.retryPolicy.incrementRetryCount(this.getClientId());
 	}
 	
 	// actual send on the SenderLink should happen only in this method & should run on Reactor Thread

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -447,48 +447,44 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 
 			this.onOpenComplete(completionException);
 
-			if (completionException != null &&
-					(!(completionException instanceof ServiceBusException) || !((ServiceBusException) completionException).getIsTransient()))
+			final Map.Entry<String, ReplayableWorkItem<Void>> pendingSendEntry = IteratorUtil.getFirst(this.pendingSendsData.entrySet());
+			if (pendingSendEntry != null && pendingSendEntry.getValue() != null)
 			{
-				synchronized (this.pendingSendLock)
+				final TimeoutTracker tracker = pendingSendEntry.getValue().getTimeoutTracker();
+				if (tracker != null)
 				{
-					for (Map.Entry<String, ReplayableWorkItem<Void>> pendingSend: this.pendingSendsData.entrySet())
+					final Duration nextRetryInterval = this.retryPolicy.getNextRetryInterval(this.getClientId(), completionException, tracker.remaining());
+					if (nextRetryInterval != null)
 					{
-						this.cleanupFailedSend(pendingSend.getValue(), completionException);					
-					}
-		
-					this.pendingSendsData.clear();
-					this.pendingSends.clear();
-				}
-			}
-			else
-			{
-				final Map.Entry<String, ReplayableWorkItem<Void>> pendingSendEntry = IteratorUtil.getFirst(this.pendingSendsData.entrySet());
-				if (pendingSendEntry != null && pendingSendEntry.getValue() != null)
-				{
-					final TimeoutTracker tracker = pendingSendEntry.getValue().getTimeoutTracker();
-					if (tracker != null)
-					{
-						final Duration nextRetryInterval = this.retryPolicy.getNextRetryInterval(this.getClientId(), completionException, tracker.remaining());
-						if (nextRetryInterval != null)
+						try
 						{
-							try
+							this.underlyingFactory.scheduleOnReactorThread((int) nextRetryInterval.toMillis(), new DispatchHandler()
 							{
-								this.underlyingFactory.scheduleOnReactorThread((int) nextRetryInterval.toMillis(), new DispatchHandler()
+								@Override
+								public void onEvent()
 								{
-									@Override
-									public void onEvent()
+									if (sendLink.getLocalState() == EndpointState.CLOSED || sendLink.getRemoteState() == EndpointState.CLOSED)
 									{
-										if (sendLink.getLocalState() == EndpointState.CLOSED || sendLink.getRemoteState() == EndpointState.CLOSED)
-										{
-											createSendLink();
-										}
+										createSendLink();
 									}
-								});
-							}
-							catch (IOException ignore)
+								}
+							});
+						}
+						catch (IOException ignore)
+						{
+						}
+					}
+					else
+					{
+						synchronized (this.pendingSendLock)
+						{
+							for (Map.Entry<String, ReplayableWorkItem<Void>> pendingSend: this.pendingSendsData.entrySet())
 							{
+								this.cleanupFailedSend(pendingSend.getValue(), completionException);					
 							}
+				
+							this.pendingSendsData.clear();
+							this.pendingSends.clear();
 						}
 					}
 				}

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ServiceBusException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ServiceBusException.java
@@ -28,9 +28,6 @@ public class ServiceBusException extends Exception
 		this.isTransient = isTransient;
 	}
 
-	/**
-	 * Constructor for the base error case
-	 */
 	public ServiceBusException(final boolean isTransient, final Throwable cause)
 	{
 		super(cause);


### PR DESCRIPTION
1. Transient errors should bubble-up to client after retryCount limit exceeds 
2. Fix a bug in code path: ConnectionCreation should be lazy - triggered by actual operation
****sender testing in progress. recv'r already tested.