### PR TITLE
emit client version & platform information to EventHubs service

### DIFF
--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -4,8 +4,8 @@
  */
 package com.microsoft.azure.servicebus;
 
-import java.time.*;
-import org.apache.qpid.proton.amqp.*;
+import java.time.Duration;
+import org.apache.qpid.proton.amqp.Symbol;
 
 import com.microsoft.azure.servicebus.amqp.AmqpConstants;
 
@@ -46,4 +46,29 @@ public final class ClientConstants
 
 	public final static String NO_RETRY = "NoRetry";
 	public final static String DEFAULT_RETRY = "Default";
+	
+	public final static String PRODUCT_NAME = "MSJavaClient";
+	public final static String CURRENT_JAVACLIENT_VERSION = "0.8.1";
+
+	public static final String PLATFORM_INFO = getPlatformInfo();
+
+	private static String getPlatformInfo()
+	{
+		final Package javaRuntimeClassPkg = Runtime.class.getPackage();
+		final StringBuilder patformInfo = new StringBuilder();
+		patformInfo.append("jre:");
+		patformInfo.append(javaRuntimeClassPkg.getImplementationVersion());
+		patformInfo.append(";vendor:");
+		patformInfo.append(javaRuntimeClassPkg.getImplementationVendor());
+		patformInfo.append(";jvm:");
+		patformInfo.append(System.getProperty("java.vm.version"));
+		patformInfo.append(";arch:");
+		patformInfo.append(System.getProperty("os.arch"));
+		patformInfo.append(";os:");
+		patformInfo.append(System.getProperty("os.name"));
+		patformInfo.append(";os version:");
+		patformInfo.append(System.getProperty("os.version"));
+
+		return patformInfo.toString();
+	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpConstants.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpConstants.java
@@ -49,6 +49,10 @@ public final class AmqpConstants
 
 	public static final Symbol STRING_FILTER = Symbol.valueOf(APACHE + ":selector-filter:string");
 	public static final Symbol EPOCH = Symbol.valueOf(VENDOR + ":epoch");
+	
+	public static final Symbol PRODUCT = Symbol.valueOf("product");
+	public static final Symbol VERSION = Symbol.valueOf("version");
+	public static final Symbol PLATFORM = Symbol.valueOf("platform");
 
 	public static final int AMQP_BATCH_MESSAGE_FORMAT = 0x80013700; // 2147563264L;
 

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
@@ -4,10 +4,13 @@
  */
 package com.microsoft.azure.servicebus.amqp;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Connection;
@@ -46,8 +49,16 @@ public final class ConnectionHandler extends BaseHandler
 	{
 		final Connection connection = event.getConnection();
 		final String hostName = event.getReactor().getConnectionAddress(connection);
+		
 		connection.setHostname(hostName);
 		connection.setContainer(StringUtil.getRandomString());
+		
+		final Map<Symbol, Object> connectionProperties = new HashMap<Symbol, Object>();
+		connectionProperties.put(AmqpConstants.PRODUCT, ClientConstants.PRODUCT_NAME);
+		connectionProperties.put(AmqpConstants.VERSION, ClientConstants.CURRENT_JAVACLIENT_VERSION);
+		connectionProperties.put(AmqpConstants.PLATFORM, ClientConstants.PLATFORM_INFO);
+		connection.setProperties(connectionProperties);
+		
 		connection.open();
 	}
 


### PR DESCRIPTION
value on wire from a test run:
properties={product=MSJavaClient, version=0.8.1, platform=jre:1.8.0_101;vendor:Oracle Corporation;jvm:25.101-b13;arch:amd64;os:Windows 10;os version:10.0}}

issue #226. 