### PR TITLE
EPH: do not create unwanted checkpoints

### DIFF
--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
@@ -513,7 +513,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     private AzureBlobLease downloadLease(CloudBlockBlob blob) throws StorageException, IOException
     {
     	String jsonLease = blob.downloadText();
-    	//this.host.logWithHost(Level.FINE, "Raw JSON downloaded: " + jsonLease);
+    	this.host.logWithHost(Level.FINEST, "Raw JSON downloaded: " + jsonLease);
     	AzureBlobLease rehydrated = this.gson.fromJson(jsonLease, AzureBlobLease.class);
     	AzureBlobLease blobLease = new AzureBlobLease(rehydrated, blob);
     	return blobLease;
@@ -525,7 +525,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
  		blob.uploadText(jsonLease, null, condition, null, null);
 		// During create, we blindly try upload and it may throw. Doing the logging after the upload
 		// avoids a spurious trace in that case.
-		//this.host.logWithHostAndPartition(Level.FINE, lease.getPartitionId(), "Raw JSON uploading for " + activity + ": " + jsonLease);
+		this.host.logWithHostAndPartition(Level.FINEST, lease.getPartitionId(), "Raw JSON uploading for " + activity + ": " + jsonLease);
     }
     
     private boolean wasLeaseLost(StorageException se, String partitionId)

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -52,13 +52,17 @@ public interface ICheckpointManager
     public Future<Checkpoint> getCheckpoint(String partitionId);
     
     /***
-     * Create the checkpoint for the given partition if it doesn't exist. Do nothing if it does exist.
+     * Create the checkpoint HOLDER for the given partition if it doesn't exist. This method is about
+     * initializing the store by ensuring that a place exists to put a checkpoint if the user creates
+     * one. This method will always return null if the checkpoint holder did not previously exist, but
+     * can return null at other times if the user has not created a checkpoint for given partition. It
+     * is legal to never create a checkpoint for a partition.
      * 
      * The offset/sequenceNumber for a freshly-created checkpoint should be set to START_OF_STREAM/0.
      * 
      * @param partitionId  Id of partition to create the checkpoint for.
      *  
-     * @return  The checkpoint for the given partition, whether newly created or already existing.
+     * @return  The checkpoint for the given partition, if one exists, or null.
      */
     public Future<Checkpoint> createCheckpointIfNotExists(String partitionId);
 

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -197,7 +197,7 @@ public class PartitionContext
     	{
         	if (inStoreCheckpoint == null)
         	{
-        		inStoreCheckpoint = this.host.getCheckpointManager().createCheckpointIfNotExists(persistThis.getPartitionId()).get();
+        		inStoreCheckpoint = persistThis;
         	}
 	    	inStoreCheckpoint.setOffset(persistThis.getOffset());
 	    	inStoreCheckpoint.setSequenceNumber(persistThis.getSequenceNumber());

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -123,6 +123,13 @@ abstract class PartitionPump
             }
         }
         
+        if (reason != CloseReason.LeaseLost)
+        {
+	        // Since this pump is dead, release the lease. 
+	        this.host.getLeaseManager().releaseLease(this.partitionContext.getLease());
+        }
+        // else we already lost the lease, releasing is unnecessary and would fail if we try
+        
         this.pumpStatus = PartitionPumpStatus.PP_CLOSED;
     }
     

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
@@ -50,7 +50,7 @@ public class PrefabEventProcessor implements IEventProcessor
 			}
 			if (Arrays.equals(event.getBody(), this.telltaleBytes))
 			{
-				this.factory.setTelltaleFound();
+				this.factory.setTelltaleFound(context.getPartitionId());
 			}
 			if (doCheckpoint)
 			{

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProcessor>
 {
@@ -14,7 +15,7 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	private boolean doMarker;
 	
 	private ArrayList<String> errors = new ArrayList<String>();
-	private boolean foundTelltale = false;
+	private HashMap<String, Boolean> foundTelltale = new HashMap<String, Boolean>(); 
 	private int eventsReceivedCount = 0;
 	
 	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker)
@@ -39,14 +40,20 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 		return this.errors.size();
 	}
 	
-	boolean getTelltaleFound()
+	boolean getTelltaleFound(String partitionId)
 	{
-		return this.foundTelltale;
+		Boolean retval = this.foundTelltale.get(partitionId);
+		return ((retval != null) ? retval : false);
 	}
 	
-	void setTelltaleFound()
+	boolean getAnyTelltaleFound()
 	{
-		this.foundTelltale = true;
+		return (this.foundTelltale.size() > 0);
+	}
+	
+	void setTelltaleFound(String partitionId)
+	{
+		this.foundTelltale.put(partitionId, true);
 	}
 	
 	synchronized void addBatch(int batchSize)

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
@@ -42,6 +42,7 @@ class RealEventHubUtilities
 {
 	private ConnectionStringBuilder hubConnectionString;
 	private String hubName;
+	private String consumerGroup = EventHubClient.DEFAULT_CONSUMER_GROUP_NAME;
 	private EventHubClient client;
 	private HashMap<String, PartitionSender> partitionSenders = new HashMap<String, PartitionSender>();
 	
@@ -52,8 +53,15 @@ class RealEventHubUtilities
 	ArrayList<String> setup() throws ServiceBusException, IOException
 	{
 		// Get the connection string from the environment
-		this.hubConnectionString = new ConnectionStringBuilder(System.getenv("EPHTESTHUB"));
+		this.hubConnectionString = new ConnectionStringBuilder(System.getenv("EVENT_HUB_CONNECTION_STRING"));
 		this.hubName = this.hubConnectionString.getEntityPath();
+		
+		// Get the consumer group from the environment, if present.
+		String tempConsumerGroup = System.getenv("EVENT_HUB_CONSUMER_GROUP");
+		if (tempConsumerGroup != null)
+		{
+			this.consumerGroup = tempConsumerGroup;
+		}
 		
 		// Get the partition ids in part to verify that the eventhub actually exists
 		ArrayList<String> partitionIds = getPartitionIds();
@@ -81,6 +89,11 @@ class RealEventHubUtilities
 	String getHubName()
 	{
 		return this.hubName;
+	}
+	
+	String getConsumerGroup()
+	{
+		return this.consumerGroup;
 	}
 	
 	void sendToAny(String body, int count) throws ServiceBusException

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
@@ -13,13 +13,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.servicebus.DebugThread;
+//import com.microsoft.azure.servicebus.DebugThread;
 import com.microsoft.azure.servicebus.ServiceBusException;
 
 public class SmokeTest
@@ -136,7 +137,7 @@ public class SmokeTest
 			System.out.println("\n." + factory1.getEventsReceivedCount() + "." + factory2.getEventsReceivedCount() + ":" +
 					((ThreadPoolExecutor)EventProcessorHost.getExecutorService()).getPoolSize() + ":" +
 					Thread.activeCount());
-			DebugThread.printThreadStatuses();
+			//DebugThread.printThreadStatuses();
 			Thread.sleep(100);
 		}
 	}
@@ -150,7 +151,7 @@ public class SmokeTest
 		int clientSerialNumber = 0;
 		while (true)
 		{
-			DebugThread.printThreadStatuses();
+			//DebugThread.printThreadStatuses();
 			
 			System.out.println("Client " + clientSerialNumber + " starting");
 			EventHubClient client = EventHubClient.createFromConnectionStringSync(utils.getConnectionString().toString());
@@ -300,10 +301,22 @@ public class SmokeTest
 			System.out.println(err);
 		}
 		
-		//EventProcessorHost.forceExecutorShutdown(10);
 		settings.utils.shutdown();
 		
 		System.out.println(settings.testName + " ended");
+	}
+	
+	@AfterClass
+	public static void allTestFinish()
+	{
+		try
+		{
+			EventProcessorHost.forceExecutorShutdown(20);
+		}
+		catch (InterruptedException e)
+		{
+			System.out.println("forceExecutorShutdown threw " + e.toString());
+		}
 	}
 
 	


### PR DESCRIPTION
Fix for 262: checkpoint store init creating unwanted checkpoints that made initial offset provider largely useless
Also: shutdown was not releasing partition leases. Minor problem because the leases would expire in 30 seconds at most anyway, but might as well do it right.
Also: refactor Azure Storage lease manager to centralize lease update.