### PR TITLE
Couple more fixes and new CITs

### DIFF
--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -52,16 +52,12 @@ namespace Microsoft.Azure.EventHubs.Processor
             this.eventHubContainer = this.storageClient.GetContainerReference(this.leaseContainerName);
         
             this.consumerGroupDirectory = this.eventHubContainer.GetDirectoryReference(this.host.ConsumerGroupName);
-        
-            // The only option that .NET sets on renewRequestOptions is ServerTimeout, which doesn't exist in Java equivalent.
-            // So right now renewRequestOptions is completely default, but keep it around in case we need to change something later.
         }
 
         //
         // In this implementation, checkpoints are data that's actually in the lease blob, so checkpoint operations
         // turn into lease operations under the covers.
         //
-
         public Task<bool> CheckpointStoreExistsAsync()
         {
             return LeaseStoreExistsAsync();
@@ -197,12 +193,12 @@ namespace Microsoft.Azure.EventHubs.Processor
     	    AzureBlobLease retval = null;
 
             CloudBlockBlob leaseBlob = this.consumerGroupDirectory.GetBlockBlobReference(partitionId);
-		    if (await leaseBlob.ExistsAsync())
+            if (await leaseBlob.ExistsAsync())
 		    {
-			    retval = await DownloadLeaseAsync(partitionId, leaseBlob);
+                retval = await DownloadLeaseAsync(partitionId, leaseBlob);
 		    }
 
-    	    return retval;
+            return retval;
         }
 
         public IEnumerable<Task<Lease>> GetAllLeases()

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/AzureStorageCheckpointLeaseManager.cs
@@ -48,9 +48,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             BlobRequestOptions options = new BlobRequestOptions();
             options.MaximumExecutionTime = AzureStorageCheckpointLeaseManager.storageMaximumExecutionTime;
             this.storageClient.DefaultRequestOptions = options;
-        
             this.eventHubContainer = this.storageClient.GetContainerReference(this.leaseContainerName);
-        
             this.consumerGroupDirectory = this.eventHubContainer.GetDirectoryReference(this.host.ConsumerGroupName);
         }
 

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                 this.partitionReceiveHandler = new PartitionReceiveHandler(this);
                 // IEventProcessor.OnOpen is called from the base PartitionPump and must have returned in order for execution to reach here, 
                 // meaning it is safe to set the handler and start calling IEventProcessor.OnEvents.
-                // Set the status to running before setting the javaClient handler, so the IEventProcessor.OnEvents can never race and see status != running.
+                // Set the status to running before setting the client handler, so the IEventProcessor.OnEvents can never race and see status != running.
                 this.PumpStatus = PartitionPumpStatus.Running;
                 this.partitionReceiver.SetReceiveHandler(this.partitionReceiveHandler);
             }
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.EventHubs.Processor
 
             public Task ProcessEventsAsync(IEnumerable<EventData> events)
             {
-                // This method is called on the thread that the Java EH client uses to run the pump.
+                // This method is called on the thread that the EH client uses to run the pump.
                 // There is one pump per EventHubClient. Since each PartitionPump creates a new EventHubClient,
                 // using that thread to call OnEvents does no harm. Even if OnEvents is slow, the pump will
                 // get control back each time OnEvents returns, and be able to receive a new batch of messages

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
@@ -23,19 +23,16 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// Azure Storage account specified by the storageConnectionString parameter is used by the built-in
         /// managers to record leases and checkpoints.
         /// </summary>
-        /// <param name="eventHubPath">The path of the Event Hub.</param>
         /// <param name="consumerGroupName">The name of the consumer group within the Event Hub.</param>
         /// <param name="eventHubConnectionString">Connection string for the Event Hub to receive from.</param>
         /// <param name="storageConnectionString">Connection string to Azure Storage account used for leases and checkpointing.</param>
         /// <param name="leaseContainerName">Azure Storage container name for use by built-in lease and checkpoint manager.</param>
         public EventProcessorHost(
-            string eventHubPath,
             string consumerGroupName,
             string eventHubConnectionString,
             string storageConnectionString,
             string leaseContainerName)
             : this(EventProcessorHost.CreateHostName(null),
-                eventHubPath,
                 consumerGroupName,
                 eventHubConnectionString,
                 storageConnectionString,
@@ -49,20 +46,17 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// <para>This overload of the constructor uses the default, built-in lease and checkpoint managers.</para>
         /// </summary>
         /// <param name="hostName">A name for this event processor host. See method notes.</param>
-        /// <param name="eventHubPath">The path of the Event Hub.</param>
         /// <param name="consumerGroupName">The name of the consumer group within the Event Hub.</param>
         /// <param name="eventHubConnectionString">Connection string for the Event Hub to receive from.</param>
         /// <param name="storageConnectionString">Connection string to Azure Storage account used for leases and checkpointing.</param>
         /// <param name="leaseContainerName">Azure Storage container name for use by built-in lease and checkpoint manager.</param>
         public EventProcessorHost(
             string hostName,
-            string eventHubPath,
             string consumerGroupName,
             string eventHubConnectionString,
             string storageConnectionString,
             string leaseContainerName)
             : this(hostName,
-                eventHubPath, 
                 consumerGroupName,
                 eventHubConnectionString,
                 new AzureStorageCheckpointLeaseManager(storageConnectionString, leaseContainerName))
@@ -79,25 +73,18 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// ones based on Azure Storage.</para>
         /// </summary>
         /// <param name="hostName">Name of the processor host. MUST BE UNIQUE. Strongly recommend including a Guid to ensure uniqueness.</param>
-        /// <param name="eventHubPath">The path of the Event Hub.</param>
         /// <param name="consumerGroupName">The name of the consumer group within the Event Hub.</param>
         /// <param name="eventHubConnectionString">Connection string for the Event Hub to receive from.</param>
         /// <param name="checkpointManager">Object implementing ICheckpointManager which handles partition checkpointing.</param>
         /// <param name="leaseManager">Object implementing ILeaseManager which handles leases for partitions.</param>
         public EventProcessorHost(
              string hostName,
-             string eventHubPath,
              string consumerGroupName,
              string eventHubConnectionString,
              ICheckpointManager checkpointManager,
              ILeaseManager leaseManager)
         {
-            if (string.IsNullOrEmpty(hostName) || string.IsNullOrEmpty(eventHubPath))
-            {
-                throw new ArgumentNullException(
-                    string.IsNullOrEmpty(hostName) ? nameof(hostName) : nameof(eventHubPath));
-            }
-            else if (string.IsNullOrEmpty(consumerGroupName))
+            if (string.IsNullOrEmpty(consumerGroupName))
             {
                 throw new ArgumentNullException(nameof(consumerGroupName));
             }
@@ -106,26 +93,33 @@ namespace Microsoft.Azure.EventHubs.Processor
                 throw new ArgumentNullException(checkpointManager == null ? nameof(checkpointManager) : nameof(leaseManager));
             }
 
+            // Entity path is expected in the connection string.
+            var connectionSettings = new EventHubsConnectionSettings(eventHubConnectionString);
+            if (string.IsNullOrEmpty(connectionSettings.EntityPath))
+            {
+                throw new ArgumentException(nameof(eventHubConnectionString),
+                    "Provided eventHubConnectionString is missing the EventHub entity path.");
+            }
+
             this.HostName = hostName;
-            this.EventHubPath = eventHubPath;
+            this.EventHubPath = connectionSettings.EntityPath;
             this.ConsumerGroupName = consumerGroupName;
             this.eventHubConnectionString = eventHubConnectionString;
             this.CheckpointManager = checkpointManager;
             this.LeaseManager = leaseManager;
             this.Id = $"EventProcessorHost({hostName.Substring(0, Math.Min(hostName.Length, 20))}...)";
             this.PartitionManager = new PartitionManager(this);
-            ProcessorEventSource.Log.EventProcessorHostCreated(this.Id, eventHubPath);
+            ProcessorEventSource.Log.EventProcessorHostCreated(this.Id, this.EventHubPath);
         }
 
         // Using this intermediate constructor to create single combined manager to be used as 
         // both lease manager and checkpoint manager.
         EventProcessorHost(
                 string hostName,
-                string eventHubPath,
                 string consumerGroupName,
                 string eventHubConnectionString,
                 AzureStorageCheckpointLeaseManager combinedManager)
-            : this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager)
+            : this(hostName, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager)
         {
         }
         

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// that take a hostName argument.
         ///  
         /// If a prefix is supplied, the constructed name begins with that string. If the prefix argument is null or
-        /// an empty string, the constructed name begins with "javahost". Then a dash '-' and a unique ID are appended to
+        /// an empty string, the constructed name begins with "host". Then a dash '-' and a unique ID are appended to
         /// create a unique name.
         /// </summary>
         /// <param name="prefix">String to use as the beginning of the name. If null or empty, a default is used.</param>

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/PartitionPump.cs
@@ -139,6 +139,13 @@ namespace Microsoft.Azure.EventHubs.Processor
                 ProcessorEventSource.Log.PartitionPumpInvokeProcessorEventsStart(this.Host.Id, this.PartitionContext.PartitionId, eventCount);
                 try
                 {
+                    if (eventCount > 0)
+                    {
+                        var lastMessage = events.Last();
+                        this.PartitionContext.SequenceNumber = lastMessage.SystemProperties.SequenceNumber;
+                        this.PartitionContext.Offset = lastMessage.SystemProperties.Offset;
+                    }
+
                     await this.Processor.ProcessEventsAsync(this.PartitionContext, events);
                 }
                 catch (Exception e)
@@ -168,10 +175,6 @@ namespace Microsoft.Azure.EventHubs.Processor
 
         protected Task ProcessErrorAsync(Exception error)
         {
-            // This handler is called when client calls the error handler we have installed.
-            // JavaClient can only do that when execution is down in javaClient. Therefore no onEvents
-            // call can be in progress right now. JavaClient will not get control back until this handler
-            // returns, so there will be no calls to onEvents until after the user's error handler has returned.
             return this.Processor.ProcessErrorAsync(this.PartitionContext, error);
         }
     }

--- a/csharp/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Amqp/AmqpExceptionHelper.cs
@@ -75,14 +75,14 @@ namespace Microsoft.Azure.EventHubs.Amqp
             }
             else if (string.Equals(condition, AmqpErrorCode.NotFound.Value))
             {
-                //if (connectionError)
+                if (message.ToLower().Contains("status-code: 404"))
                 {
-                    return new EventHubsCommunicationException(message, null);
+                    return new MessagingEntityNotFoundException(message);
                 }
-                //else
-                //{
-                //    return new MessagingEntityNotFoundException(message, null);
-                //}
+                else
+                {
+                    return new EventHubsCommunicationException(message);
+                }
             }
             else if (string.Equals(condition, AmqpErrorCode.NotImplemented.Value))
             {
@@ -116,55 +116,6 @@ namespace Microsoft.Azure.EventHubs.Amqp
             {
                 return new EventHubsException(true, message);
             }
-
-            // else if (string.Equals(condition, AmqpClientConstants.EntityAlreadyExistsError.Value))
-            // {
-            //     return new MessagingEntityAlreadyExistsException(message, null, null);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.MessageLockLostError.Value))
-            // {
-            //     return new MessageLockLostException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.SessionLockLostError.Value))
-            // {
-            //     return new SessionLockLostException(message);
-            // }
-            // else if (string.Equals(condition, AmqpErrorCode.ResourceLimitExceeded.Value))
-            // {
-            //     return new Microsoft.ServiceBus.Messaging.QuotaExceededException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.NoMatchingSubscriptionError.Value))
-            // {
-            //     return new NoMatchingSubscriptionException(message);
-            // }
-            // else if (string.Equals(condition, AmqpErrorCode.MessageSizeExceeded.Value))
-            // {
-            //     return new MessageSizeExceededException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.StoreLockLostError.Value))
-            // {
-            //     return new MessageStoreLockLostException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.SessionCannotBeLockedError.Value))
-            // {
-            //     return new SessionCannotBeLockedException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.PartitionNotOwnedError.Value))
-            // {
-            //     return new PartitionNotOwnedException(message);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.EntityDisabledError.Value))
-            // {
-            //     return new MessagingEntityDisabledException(message, null);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.PublisherRevokedError.Value))
-            // {
-            //     return new PublisherRevokedException(message, null);
-            // }
-            // else if (string.Equals(condition, AmqpClientConstants.MessageNotFoundError.Value))
-            // {
-            //     return new MessageNotFoundException(message);
-            // }
         }
     }
 }

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/MessageSizeExceededException.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/MessageSizeExceededException.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs
+{
+    using System;
+
+    /// <summary>
+    /// The exception is thrown when the message size exceeds what AMQP allows on the link.
+    /// </summary>
+    public sealed class MessageSizeExceededException : EventHubsException
+    {
+        public MessageSizeExceededException(string message)
+            : this(message, null)
+        {
+        }
+
+        internal MessageSizeExceededException(string message, Exception innerException)
+            : base(false, message, innerException)
+        {
+        }
+
+        internal MessageSizeExceededException(uint deliveryId, ulong size, ulong maxSize)
+            : this(Resources.AmqpMessageSizeExceeded.FormatForUser(deliveryId, size, maxSize))
+        {
+        }
+    }
+}

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityNotFoundException.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/MessagingEntityNotFoundException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs
+{
+    using System;
+
+    public sealed class MessagingEntityNotFoundException : EventHubsException
+    {
+        public MessagingEntityNotFoundException(string message)
+            : base(false, message, null)
+        {
+        }
+    }
+}

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/RetryPolicy.cs
@@ -55,6 +55,10 @@ namespace Microsoft.Azure.EventHubs
             {
                 return ((EventHubsException)exception).IsTransient;
             }
+            else if (exception is OperationCanceledException)
+            {
+                return true;
+            }
 
             return false;
         }

--- a/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -49,7 +49,6 @@
         async Task SingleProcessorHost()
         {
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -75,7 +74,6 @@
             {
                 WriteLine($"Creating EventProcessorHost");
                 var eventProcessorHost = new EventProcessorHost(
-                    this.ConnectionSettings.EntityPath,
                     PartitionReceiver.DefaultConsumerGroupName,
                     this.EventHubConnectionString,
                     this.StorageConnectionString,
@@ -155,7 +153,6 @@
             }
 
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -210,7 +207,6 @@
             WriteLine($"Calling RegisterEventProcessorAsync with InvokeProcessorAfterReceiveTimeout=false");
 
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -291,7 +287,6 @@
             foreach (var consumerGroupName in consumerGroupNames)
             {
                 var eventProcessorHost = new EventProcessorHost(
-                    this.ConnectionSettings.EntityPath,
                     consumerGroupName,
                     this.EventHubConnectionString,
                     this.StorageConnectionString,
@@ -349,7 +344,6 @@
 
             // Use a randomly generated container name so that initial offset provider will be respected.
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -375,7 +369,6 @@
 
             // Use a randomly generated container name so that initial offset provider will be respected.
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -401,7 +394,6 @@
 
             // First host will send and receive as usual.
             var eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -412,7 +404,6 @@
             // Since we are still on the same lease container, initial offset provider shouldn't rule.
             // We should continue receiving where we left instead if start-of-stream where initial offset provider dictates.
             eventProcessorHost = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -436,7 +427,6 @@
 
             // Consume all messages with first host.
             var eventProcessorHostFirst = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -446,7 +436,6 @@
             // Seconds time we initiate a host, it should pick from where previous host left.
             // In other words, it shouldn't start receiving from start of the stream.
             var eventProcessorHostSecond = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -469,7 +458,6 @@
 
             // Consume all messages with first host.
             var eventProcessorHostFirst = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -480,7 +468,6 @@
             // Seconds time we initiate a host, it should pick from where previous host left.
             // In other words, it shouldn't start receiving from start of the stream.
             var eventProcessorHostSecond = new EventProcessorHost(
-                this.ConnectionSettings.EntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,

--- a/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -174,7 +174,7 @@
                 processor.OnOpen += (_, partitionContext) => WriteLine($"Partition {partitionId} TestEventProcessor opened");
                 processor.OnProcessEvents += (_, eventsArgs) =>
                 {
-                    int eventCount = eventsArgs.Item2 != null ? eventsArgs.Item2.events.Count() : 0;
+                    int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
                     WriteLine($"Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
                     if (eventCount == 0)
                     {


### PR DESCRIPTION
* Adding MessageSizeExceededException
* Adding MessagingEntityNotFoundException
* Adding new client CITs:
    - CreateReceiverWithOffset()
    - CreateReceiverWithDateTime()
    - MessageSizeExceededException()
    - SendReceiveNonexistentEntity()
    - PartitionKeyValidation()
*  Replacing or removing Java references in the code comments.
*  Taking OperationCanceledException as retriable error.
*  Fixing NullRef in EPH CIT.
*  Wiring up MessagingEntityNotFoundException in AmqpExceptionHelper
*  Handling link creation failure such as MessagingEntityNotFoundException on the sender.
*  PartitionPump to update offset/sequencenumber on the PartitionContext so that Checkpoint() call can respect the last message delivered.
* Removing entityPath parameter from EPH constructors since entity path is mandatory in connection string and having the same path in 2 different places can easily break consistency.