### PR TITLE
EventHubsConnectionSettings optional param

### DIFF
--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/EventProcessorHost.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             ProcessorEventSource.Log.EventProcessorHostOpenStart(this.Id, factory.GetType().ToString());
             try
             {
-                this.ConnectionSettings = new EventHubsConnectionSettings(this.eventHubConnectionString);
+                this.ConnectionSettings = new EventHubsConnectionSettings(this.eventHubConnectionString, this.EventHubPath);
                 this.ConnectionSettings.OperationTimeout = processorOptions.ReceiveTimeout;
 
                 if (this.initializeLeaseManager)

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionSettings.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionSettings.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.EventHubs
         /// Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;SharedAccessKeyName=SHARED_ACCESS_KEY_NAME;SharedAccessKey=SHARED_ACCESS_KEY
         /// </summary>
         /// <param name="connectionString">Event Hubs ConnectionString</param>
-        public EventHubsConnectionSettings(string connectionString)
+        public EventHubsConnectionSettings(string connectionString, string entityPath = null)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -102,6 +102,11 @@ namespace Microsoft.Azure.EventHubs
             this.OperationTimeout = DefaultOperationTimeout;
             this.RetryPolicy = RetryPolicyType.Default;
             this.ParseConnectionString(connectionString);
+
+            if (!string.IsNullOrWhiteSpace(entityPath))
+            {
+                this.EntityPath = entityPath;
+            }
         }
 
         public Uri Endpoint { get; set; }

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionSettings.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionSettings.cs
@@ -88,10 +88,13 @@ namespace Microsoft.Azure.EventHubs
         }
 
         /// <summary>
+        /// Creates an EventHubsConnectionSettings object with a connection string and an optional entity path.
+        /// If the entity path is supplied in the connection string, the optional parameter will be ignored.
         /// ConnectionString format:
         /// Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;SharedAccessKeyName=SHARED_ACCESS_KEY_NAME;SharedAccessKey=SHARED_ACCESS_KEY
         /// </summary>
         /// <param name="connectionString">Event Hubs ConnectionString</param>
+        /// <param name="entityPath">Optional parameter for the Event Hub path / Event Hub name</param>
         public EventHubsConnectionSettings(string connectionString, string entityPath = null)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -103,7 +106,7 @@ namespace Microsoft.Azure.EventHubs
             this.RetryPolicy = RetryPolicyType.Default;
             this.ParseConnectionString(connectionString);
 
-            if (!string.IsNullOrWhiteSpace(entityPath))
+            if (!string.IsNullOrWhiteSpace(entityPath) && string.IsNullOrWhiteSpace(this.EntityPath))
             {
                 this.EntityPath = entityPath;
             }


### PR DESCRIPTION
Added optional entity name param to EventHubsConnectionSettings constructor so that you can allow the EPH to pass a connection string without the entitypath. Using the optional param allows you to always pass the param and handle the null check inside the constructor rather than in the calling method.