### PR TITLE
Various client and EPH changes.

### DIFF
--- a/csharp/samples/SampleEphReceiver/Program.cs
+++ b/csharp/samples/SampleEphReceiver/Program.cs
@@ -19,19 +19,12 @@ namespace SampleEphReceiver
 
         public static void Main(string[] args)
         {
-            // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
-            // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
-            // we are using the connection string from the namespace.
-            var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
-            {
-                EntityPath = EhEntityPath
-            };
-
             Console.WriteLine("Registering EventProcessor...");
 
             var eventProcessorHost = new EventProcessorHost(
+                EhEntityPath,
                 PartitionReceiver.DefaultConsumerGroupName,
-                connectionSettings.ToString(),
+                EhConnectionString,
                 StorageConnectionString,
                 StorageContainerName);
 

--- a/csharp/samples/SampleEphReceiver/getting-started-receiving-eph.md
+++ b/csharp/samples/SampleEphReceiver/getting-started-receiving-eph.md
@@ -109,19 +109,12 @@ In this tutorial, we will write a .NET Core console application to receive messa
 3. Add the following code to the `Main` method:
 
     ```cs
-    // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
-    // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
-    // we are using the connection string from the namespace.
-    var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
-    {
-        EntityPath = EhEntityPath
-    };
-
     Console.WriteLine("Registering EventProcessor...");
 
     var eventProcessorHost = new EventProcessorHost(
+	    EhEntityPath,
         PartitionReceiver.DefaultConsumerGroupName,
-        connectionSettings.ToString(),
+        EhConnectionString,
         StorageConnectionString,
         StorageContainerName);
 
@@ -156,19 +149,12 @@ In this tutorial, we will write a .NET Core console application to receive messa
 
             public static void Main(string[] args)
             {
-                // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
-			    // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
-			    // we are using the connection string from the namespace.
-                var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
-                {
-                    EntityPath = EhEntityPath
-                };
-
                 Console.WriteLine("Registering EventProcessor...");
 
                 var eventProcessorHost = new EventProcessorHost(
+					EhEntityPath,
                     PartitionReceiver.DefaultConsumerGroupName,
-                    connectionSettings.ToString(),
+                    EhConnectionString,
                     StorageConnectionString,
                     StorageContainerName);
 

--- a/csharp/samples/SampleSender/Program.cs
+++ b/csharp/samples/SampleSender/Program.cs
@@ -23,15 +23,15 @@ namespace SampleSender
         // Creates an Event Hub client and sends 100 messages to the event hub.
         private static async Task SendMessagesToEventHub(int numMessagesToSend)
         {
-            // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
+            // Creates an EventHubsConnectionStringBuilder object from a the connection string, and sets the EntityPath.
             // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
             // we are using the connection string from the namespace.
-            var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
+            var connectionStringBuilder = new EventHubsConnectionStringBuilder(EhConnectionString)
             {
                 EntityPath = EhEntityPath
             };
 
-            var eventHubClient = EventHubClient.Create(connectionSettings);
+            var eventHubClient = EventHubClient.CreateFromConnectionString(connectionStringBuilder.ToString());
 
             for (var i = 0; i < numMessagesToSend; i++)
             {

--- a/csharp/samples/SampleSender/getting-started-sending.md
+++ b/csharp/samples/SampleSender/getting-started-sending.md
@@ -50,15 +50,15 @@ To send messages to an Event Hub, we will write a C# console application using V
     ```cs
     private static async Task SendMessagesToEventHub(int numMessagesToSend)
     {
-        // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
+        // Creates an EventHubsConnectionStringBuilder object from a the connection string, and sets the EntityPath.
         // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
         // we are using the connection string from the namespace.
-        var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
+        var connectionStringBuilder = new EventHubsConnectionStringBuilder(EhConnectionString)
         {
             EntityPath = EhEntityPath
         };
 
-        var eventHubClient = EventHubClient.Create(connectionSettings);
+        var eventHubClient = EventHubClient.Create(connectionStringBuilder);
 
         for (var i = 0; i < numMessagesToSend; i++)
         {
@@ -113,15 +113,15 @@ To send messages to an Event Hub, we will write a C# console application using V
             // Creates an Event Hub client and sends 100 messages to the event hub.
             private static async Task SendMessagesToEventHub(int numMessagesToSend)
             {
-                // Creates an EventHubsConnectionSettings object from a the connection string, and sets the EntityPath.
+                // Creates an EventHubsConnectionStringBuilder object from a the connection string, and sets the EntityPath.
                 // Typically the connection string should have the Entity Path in it, but for the sake of this simple scenario
                 // we are using the connection string from the namespace.
-                var connectionSettings = new EventHubsConnectionSettings(EhConnectionString)
+                var connectionStringBuilder = new EventHubsConnectionStringBuilder(EhConnectionString)
                 {
                     EntityPath = EhEntityPath
                 };
 
-                var eventHubClient = EventHubClient.Create(connectionSettings);
+                var eventHubClient = EventHubClient.Create(connectionStringBuilder);
 
                 for (var i = 0; i < numMessagesToSend; i++)
                 {

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/EventHubPartitionPump.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             object startAt = await this.PartitionContext.GetInitialOffsetAsync();
             long epoch = this.Lease.Epoch;
             ProcessorEventSource.Log.PartitionPumpCreateClientsStart(this.Host.Id, this.PartitionContext.PartitionId, epoch, startAt);
-		    this.eventHubClient = EventHubClient.Create(this.Host.ConnectionSettings);
+		    this.eventHubClient = EventHubClient.CreateFromConnectionString(this.Host.EventHubConnectionString);
 
             // Create new receiver and set options
             if (startAt is string)

--- a/csharp/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs.Processor/PartitionManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.EventHubs.Processor
                 EventHubClient eventHubClient = null;
                 try
                 {
-                    eventHubClient = EventHubClient.Create(this.host.ConnectionSettings);
+                    eventHubClient = EventHubClient.CreateFromConnectionString(this.host.EventHubConnectionString);
                     var runtimeInfo = await eventHubClient.GetRuntimeInformationAsync();
                     this.partitionIds = runtimeInfo.PartitionIds.ToList();
                 }

--- a/csharp/src/Microsoft.Azure.EventHubs/Amqp/ActiveClientLinkManager.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Amqp/ActiveClientLinkManager.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     cbsLink = new AmqpCbsLink(thisPtr.activeClientLink.Connection);
                 }
 
-                var validTo = await cbsLink.SendTokenAsync(thisPtr.eventHubClient.CbsTokenProvider, thisPtr.eventHubClient.ConnectionSettings.Endpoint,
+                var validTo = await cbsLink.SendTokenAsync(
+                    thisPtr.eventHubClient.CbsTokenProvider,
+                    thisPtr.eventHubClient.ConnectionStringBuilder.Endpoint,
                     thisPtr.activeClientLink.Audience, thisPtr.activeClientLink.EndpointUri,
                     thisPtr.activeClientLink.RequiredClaims,
                     ActiveClientLinkManager.SendTokenTimeout);

--- a/csharp/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Amqp/AmqpEventHubClient.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             this.ContainerId = Guid.NewGuid().ToString("N");
             this.AmqpVersion = new Version(1, 0, 0, 0);
             this.MaxFrameSize = AmqpConstants.DefaultMaxFrameSize;
-            this.TokenProvider = csb.CreateTokenProvider();
+            this.TokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
             this.CbsTokenProvider = new TokenProviderAdapter(this);
             this.ConnectionManager = new FaultTolerantAmqpObject<AmqpConnection>(this.CreateConnectionAsync, this.CloseConnection);
         }

--- a/csharp/src/Microsoft.Azure.EventHubs/EventDataSender.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/EventDataSender.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Azure.EventHubs
         {
             this.EventHubClient = eventHubClient;
             this.PartitionId = partitionId;
-            this.retryPolicy = eventHubClient.ConnectionSettings.RetryPolicy;
-            this.retryPolicy.ResetRetryCount(this.ClientId);
         }
 
         protected EventHubClient EventHubClient { get; }

--- a/csharp/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/PartitionReceiver.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Azure.EventHubs
             this.StartTime = startTime;
             this.PrefetchCount = DefaultPrefetchCount;
             this.Epoch = epoch;
-            this.retryPolicy = eventHubClient.ConnectionSettings.RetryPolicy;
 
             EventHubsEventSource.Log.ClientCreated(this.ClientId, this.FormatTraceDetails());
         }
@@ -130,7 +129,7 @@ namespace Microsoft.Azure.EventHubs
         /// <returns>A Task that will yield a batch of <see cref="EventData"/> from the partition on which this receiver is created. Returns 'null' if no EventData is present.</returns>
         public Task<IEnumerable<EventData>> ReceiveAsync(int maxMessageCount)
         {
-            return this.ReceiveAsync(maxMessageCount, this.EventHubClient.ConnectionSettings.OperationTimeout);
+            return this.ReceiveAsync(maxMessageCount, this.EventHubClient.ConnectionStringBuilder.OperationTimeout);
         }
 
         /// <summary>

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/ClientEntity.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/ClientEntity.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Azure.EventHubs
     {
         static int nextId;
 
-        protected RetryPolicy retryPolicy;
-
         protected ClientEntity(string clientId)
         {
             this.ClientId = clientId;
@@ -26,6 +24,7 @@ namespace Microsoft.Azure.EventHubs
             get; private set;
         }
 
+        public RetryPolicy RetryPolicy { get; set; }
 
         public abstract Task CloseAsync();
 

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/EventHubsConnectionStringBuilder.cs
@@ -136,15 +136,6 @@ namespace Microsoft.Azure.EventHubs
         }
 
         /// <summary>
-        /// Creates a TokenProvider given the credentials in this EventHubsConnectionStringBuilder.
-        /// </summary>
-        /// <returns></returns>
-        public TokenProvider CreateTokenProvider()
-        {
-            return TokenProvider.CreateSharedAccessSignatureTokenProvider(this.SasKeyName, this.SasKey);
-        }
-
-        /// <summary>
         /// Returns an interoperable connection string that can be used to connect to Event Hubs Namespace
         /// </summary>
         /// <returns>the connection string</returns>

--- a/csharp/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
+++ b/csharp/src/Microsoft.Azure.EventHubs/Primitives/RetryExponential.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.EventHubs
 
     /// <summary>
     /// RetryPolicy implementation where the delay between retries will grow in a staggered exponential manner.
-    /// RetryPolicy can be set on the client operations using <see cref="EventHubsConnectionSettings"/>.
+    /// RetryPolicy can be set on the client using <see cref="EventHubClient"/>.
     /// RetryIntervals will be computed using a retryFactor which is a function of deltaBackOff (MaximumBackoff - MinimumBackoff) and MaximumRetryCount
     /// </summary>
     public sealed class RetryExponential : RetryPolicy

--- a/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
+++ b/csharp/test/Microsoft.Azure.EventHubs.Processor.UnitTests/EventProcessorHostTests.cs
@@ -13,7 +13,7 @@
 
     public class EventProcessorHostTests
     {
-        EventHubsConnectionSettings ConnectionSettings;
+        EventHubsConnectionStringBuilder ConnectionStringBuilder;
         string StorageConnectionString;
         string EventHubConnectionString;
         string LeaseContainerName;
@@ -33,22 +33,102 @@
                 throw new InvalidOperationException("EVENTPROCESSORSTORAGECONNECTIONSTRING environment variable was not found!");
             }
 
-            this.ConnectionSettings = new EventHubsConnectionSettings(eventHubConnectionString);
+            this.ConnectionStringBuilder = new EventHubsConnectionStringBuilder(eventHubConnectionString);
             this.StorageConnectionString = storageConnectionString;
             this.EventHubConnectionString = eventHubConnectionString;
 
             // Use entity name as lease container name.
-            this.LeaseContainerName = this.ConnectionSettings.EntityPath;
+            this.LeaseContainerName = this.ConnectionStringBuilder.EntityPath;
 
             // Discover partition ids.
-            PartitionIds = this.GetPartitionIdsAsync(this.ConnectionSettings).Result;
+            PartitionIds = this.GetPartitionIdsAsync(this.ConnectionStringBuilder.ToString()).Result;
             WriteLine($"EventHub has {PartitionIds.Length} partitions");
+        }
+
+        /// <summary>
+        /// Validating cases where entity path is provided through eventHubPath and EH connection string parameters
+        /// on the EPH constructor.
+        /// </summary>
+        [Fact]
+        void ProcessorHostEntityPathSetting()
+        {
+            var csb = new EventHubsConnectionStringBuilder(this.EventHubConnectionString);
+            csb.EntityPath = "myeh";
+
+            // Entity path provided in the connection string.
+            WriteLine("Testing condition: Entity path provided in the connection string only.");
+            var eventProcessorHost = new EventProcessorHost(
+                null,
+                PartitionReceiver.DefaultConsumerGroupName,
+                csb.ToString(),
+                this.StorageConnectionString,
+                this.LeaseContainerName);
+            Assert.Equal("myeh", eventProcessorHost.EventHubPath);
+
+            // Entity path provided in the eventHubPath parameter.
+            WriteLine("Testing condition: Entity path provided in the eventHubPath only.");
+            csb.EntityPath = null;
+            eventProcessorHost = new EventProcessorHost(
+                "myeh2",
+                PartitionReceiver.DefaultConsumerGroupName,
+                csb.ToString(),
+                this.StorageConnectionString,
+                this.LeaseContainerName);
+            Assert.Equal("myeh2", eventProcessorHost.EventHubPath);
+
+            // The same entity path provided in both eventHubPath parameter and the connection string.
+            WriteLine("Testing condition: The same entity path provided in the eventHubPath and connection string.");
+            csb.EntityPath = "mYeH";
+            eventProcessorHost = new EventProcessorHost(
+                "myeh",
+                PartitionReceiver.DefaultConsumerGroupName,
+                csb.ToString(),
+                this.StorageConnectionString,
+                this.LeaseContainerName);
+            Assert.Equal("myeh", eventProcessorHost.EventHubPath);
+
+            // Entity path not provided in both eventHubPath and the connection string.
+            WriteLine("Testing condition: Entity path not provided in both eventHubPath and connection string.");
+            try
+            {
+                csb.EntityPath = null;
+                eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    csb.ToString(),
+                    this.StorageConnectionString,
+                    this.LeaseContainerName);
+                throw new Exception("Entity path wasn't provided and this new call was supposed to fail");
+            }
+            catch (ArgumentException)
+            {
+                WriteLine("Caught ArgumentException as expected.");
+            }
+
+            // Entity path conflict.
+            WriteLine("Testing condition: Entity path conflict.");
+            try
+            {
+                csb.EntityPath = "myeh";
+                eventProcessorHost = new EventProcessorHost(
+                    "myeh2",
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    csb.ToString(),
+                    this.StorageConnectionString,
+                    this.LeaseContainerName);
+                throw new Exception("Entity path values conflict and this new call was supposed to fail");
+            }
+            catch (ArgumentException)
+            {
+                WriteLine("Caught ArgumentException as expected.");
+            }
         }
 
         [Fact]
         async Task SingleProcessorHost()
         {
             var eventProcessorHost = new EventProcessorHost(
+                null,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -61,6 +141,7 @@
         async Task HostReregisterShouldFail()
         {
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -111,6 +192,7 @@
             {
                 WriteLine($"Creating EventProcessorHost");
                 var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
                     PartitionReceiver.DefaultConsumerGroupName,
                     this.EventHubConnectionString,
                     this.StorageConnectionString,
@@ -154,7 +236,7 @@
             var sendTasks = new List<Task>();
             foreach (var partitionId in PartitionIds)
             {
-                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionSettings));
+                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionStringBuilder.ToString()));
             }
             await Task.WhenAll(sendTasks);
 
@@ -190,6 +272,7 @@
             }
 
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -244,6 +327,7 @@
             WriteLine($"Calling RegisterEventProcessorAsync with InvokeProcessorAfterReceiveTimeout=false");
 
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -324,6 +408,7 @@
             foreach (var consumerGroupName in consumerGroupNames)
             {
                 var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
                     consumerGroupName,
                     this.EventHubConnectionString,
                     this.StorageConnectionString,
@@ -344,7 +429,7 @@
             var sendTasks = new List<Task>();
             foreach (var partitionId in PartitionIds)
             {
-                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionSettings));
+                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionStringBuilder.ToString()));
             }
 
             await Task.WhenAll(sendTasks);
@@ -381,6 +466,7 @@
 
             // Use a randomly generated container name so that initial offset provider will be respected.
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -406,6 +492,7 @@
 
             // Use a randomly generated container name so that initial offset provider will be respected.
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -431,6 +518,7 @@
 
             // First host will send and receive as usual.
             var eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -441,6 +529,7 @@
             // Since we are still on the same lease container, initial offset provider shouldn't rule.
             // We should continue receiving where we left instead if start-of-stream where initial offset provider dictates.
             eventProcessorHost = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -464,6 +553,7 @@
 
             // Consume all messages with first host.
             var eventProcessorHostFirst = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -473,6 +563,7 @@
             // For the second time we initiate a host and this time it should pick from where the previous host left.
             // In other words, it shouldn't start receiving from start of the stream.
             var eventProcessorHostSecond = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -491,6 +582,7 @@
 
             // Consume all messages with first host.
             var eventProcessorHostFirst = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -500,6 +592,7 @@
             // For the second time we initiate a host and this time it should pick from where the previous host left.
             // In other words, it shouldn't start receiving from start of the stream.
             var eventProcessorHostSecond = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -522,6 +615,7 @@
 
             // Consume all messages with first host.
             var eventProcessorHostFirst = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -532,6 +626,7 @@
             // Seconds time we initiate a host, it should pick from where previous host left.
             // In other words, it shouldn't start receiving from start of the stream.
             var eventProcessorHostSecond = new EventProcessorHost(
+                string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
                 this.EventHubConnectionString,
                 this.StorageConnectionString,
@@ -551,13 +646,13 @@
             var sendTasks = new List<Task>();
             foreach (var partitionId in PartitionIds)
             {
-                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionSettings));
+                sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionStringBuilder.ToString()));
             }
 
             await Task.WhenAll(sendTasks);
 
             // Receive all events including last events from each partition.
-            var ehClient = EventHubClient.Create(this.ConnectionSettings);
+            var ehClient = EventHubClient.CreateFromConnectionString(this.ConnectionStringBuilder.ToString());
             ConcurrentDictionary<string, EventData> lastEvents = new ConcurrentDictionary<string, EventData>();
             var receiveTasks = PartitionIds.Select(async partitionId =>
                 {
@@ -639,7 +734,7 @@
                 {
                     for (int i = 0; i < totalNumberOfEventsToSend; i++)
                     {
-                        sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionSettings));
+                        sendTasks.Add(this.SendToPartitionAsync(partitionId, $"{partitionId} event.", this.ConnectionStringBuilder.ToString()));
                     }
                 }
 
@@ -668,9 +763,9 @@
             return receivedEvents.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        async Task<string[]> GetPartitionIdsAsync(EventHubsConnectionSettings connectionSettings)
+        async Task<string[]> GetPartitionIdsAsync(string connectionString)
         {
-            var eventHubClient = EventHubClient.Create(connectionSettings);
+            var eventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
             try
             {
                 var eventHubInfo = await eventHubClient.GetRuntimeInformationAsync();
@@ -682,9 +777,9 @@
             }
         }
 
-        async Task SendToPartitionAsync(string partitionId, string messageBody, EventHubsConnectionSettings connectionSettings)
+        async Task SendToPartitionAsync(string partitionId, string messageBody, string connectionString)
         {
-            var eventHubClient = EventHubClient.Create(connectionSettings);
+            var eventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
             try
             {
                 var partitionSender = eventHubClient.CreatePartitionSender(partitionId);


### PR DESCRIPTION
- Renaming EventsHubConnectionSettings to EventsHubConnectionStringBuilder
- Enabling custom retry policy.
- Moving retry policy to client and removing it from connection string builder.
- Avoid path conflict between eventHubPath and the path in the connection string when instantiating EPH.
- ReceiveTimeout in processor options will override the OperationTimeout value from connection string.
- Adding eventHubPath back to EPH constructors
- Sample changes due to client API recent changes.
- Client CITS: Adding ConnectionStringBuilderTest and CreateClientWithoutEntityPathShouldFail
- EPH CITS: Connection string builder changes and adding ProcessorHostEntityPathSetting.