### PR TITLE
Add blob name prefix, add user-supplied ExecutorService, deprecate setOffsetAndSequenceNumber

### DIFF
--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -120,8 +120,33 @@ public final class EventProcessorHost
             final String storageConnectionString,
             final String storageContainerName)
     {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param storageBlobPrefix			Prefix used when naming blobs within the storage container.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final String storageBlobPrefix)
+    {
         this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString,
-                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName));
+                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix));
         this.initializeLeaseManager = true;
     }
     

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -34,7 +34,7 @@ public final class EventProcessorHost
     // weOwnExecutor exists to support user-supplied thread pools if we add that feature later.
     // weOwnExecutor is a boxed Boolean so it can be used to synchronize access to these variables.
     // executorRefCount is required because the last host must shut down the thread pool if we own it.
-    private static ExecutorService executorService = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = null;
     private static int executorRefCount = 0;
     private static Boolean weOwnExecutor = true;
     private static boolean autoShutdownExecutor = false;
@@ -96,7 +96,8 @@ public final class EventProcessorHost
             final String eventHubConnectionString,
             final String storageConnectionString)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, new AzureStorageCheckpointLeaseManager(storageConnectionString));
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, new AzureStorageCheckpointLeaseManager(storageConnectionString), 
+        		(ExecutorService)null);
         this.initializeLeaseManager = true;
     }
 
@@ -120,7 +121,32 @@ public final class EventProcessorHost
             final String storageConnectionString,
             final String storageContainerName)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, null);
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, (ExecutorService)null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final ExecutorService executorService)
+    {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, (String)null, executorService);
     }
 
     /**
@@ -145,8 +171,36 @@ public final class EventProcessorHost
             final String storageContainerName,
             final String storageBlobPrefix)
     {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, storageBlobPrefix,
+        		(ExecutorService)null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param storageBlobPrefix			Prefix used when naming blobs within the storage container.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final String storageBlobPrefix,
+            final ExecutorService executorService)
+    {
         this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString,
-                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix));
+                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix), executorService);
         this.initializeLeaseManager = true;
     }
     
@@ -157,10 +211,12 @@ public final class EventProcessorHost
             final String eventHubPath,
             final String consumerGroupName,
             final String eventHubConnectionString,
-            final AzureStorageCheckpointLeaseManager combinedManager)
+            final AzureStorageCheckpointLeaseManager combinedManager,
+            final ExecutorService executorService)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager);
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager, executorService);
     }
+
 
     /**
      * Create a new host to process events from an Event Hub.
@@ -168,10 +224,10 @@ public final class EventProcessorHost
      * This overload allows the caller to provide their own lease and checkpoint managers to replace the built-in
      * ones based on Azure Storage.
      * 
-     * @param hostName
-     * @param eventHubPath
-     * @param consumerGroupName
-     * @param eventHubConnectionString
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
      * @param checkpointManager			Implementation of ICheckpointManager, to be replacement checkpoint manager.
      * @param leaseManager				Implementation of ILeaseManager, to be replacement lease manager.
      */
@@ -183,6 +239,32 @@ public final class EventProcessorHost
             ICheckpointManager checkpointManager,
             ILeaseManager leaseManager)
     {
+    	this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, checkpointManager, leaseManager, null);
+    }
+    
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload allows the caller to provide their own lease and checkpoint managers to replace the built-in
+     * ones based on Azure Storage, and to provide an executor service.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+     * @param checkpointManager			Implementation of ICheckpointManager, to be replacement checkpoint manager.
+     * @param leaseManager				Implementation of ILeaseManager, to be replacement lease manager.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            ICheckpointManager checkpointManager,
+            ILeaseManager leaseManager,
+            ExecutorService executorService)
+    {
     	EventProcessorHost.TRACE_LOGGER.setLevel(Level.SEVERE);
     	
         this.hostName = hostName;
@@ -191,15 +273,41 @@ public final class EventProcessorHost
         this.eventHubConnectionString = eventHubConnectionString;
         this.checkpointManager = checkpointManager;
         this.leaseManager = leaseManager;
-        
-        if (EventProcessorHost.weOwnExecutor)
+
+        synchronized(EventProcessorHost.weOwnExecutor)
         {
-	        synchronized(EventProcessorHost.weOwnExecutor)
+	        if (EventProcessorHost.executorService != null)
 	        {
-	        	EventProcessorHost.executorRefCount++;
+	        	// An EventProcessorHost has already been instantiated in this process.
+	        	// Ignore any settings provided, just use the existing ExecutorService and
+	        	// related settings.
+	        	
+	        	// If using EventProcessorHost internal ExecutorService, increase the refcount.
+	        	if (EventProcessorHost.weOwnExecutor)
+	        	{
+	        		EventProcessorHost.executorRefCount++;
+	        	}
+	        }
+	        else
+	        {
+		        if (executorService != null)
+		        {
+		        	// User has supplied an ExecutorService, so use that.
+		        	EventProcessorHost.weOwnExecutor = false;
+		        	EventProcessorHost.executorService = executorService;
+		        	// We don't own it so refcount is meaningless.
+		        	// Make sure that auto shutdown is false!
+		        	EventProcessorHost.autoShutdownExecutor = false;
+		        }
+		        else
+		        {
+		        	EventProcessorHost.weOwnExecutor = true;
+		        	EventProcessorHost.executorService = Executors.newCachedThreadPool();
+		        	EventProcessorHost.executorRefCount++;
+		        }
 	        }
         }
-
+        
         this.partitionManager = new PartitionManager(this);
         
         logWithHost(Level.INFO, "New EventProcessorHost created");
@@ -248,6 +356,7 @@ public final class EventProcessorHost
      * class EventProcessor implements IEventProcessor { ... }
      * EventProcessorHost host = new EventProcessorHost(...);
      * Future foo = host.registerEventProcessor(EventProcessor.class);
+     * foo.get();
      * </pre>
      *  
      * @param eventProcessorType	Class that implements IEventProcessor.
@@ -368,12 +477,13 @@ public final class EventProcessorHost
     // PartitionManager calls this after all shutdown tasks have been submitted to the ExecutorService.
     void stopExecutor()
     {
-        if (EventProcessorHost.weOwnExecutor && EventProcessorHost.autoShutdownExecutor)
+        if (EventProcessorHost.weOwnExecutor)
         {
         	synchronized(EventProcessorHost.weOwnExecutor)
         	{
         		EventProcessorHost.executorRefCount--;
-        		if (EventProcessorHost.executorRefCount <= 0)
+        		
+        		if ((EventProcessorHost.executorRefCount <= 0) && EventProcessorHost.autoShutdownExecutor)
         		{
         			// It is OK to call shutdown() here even though threads are still running.
         			// Shutdown() causes the executor to stop accepting new tasks, but existing tasks will
@@ -393,24 +503,42 @@ public final class EventProcessorHost
      * only ever call unregisterEventProcess() when the process is shutting down.
      * <p>
      * If you leave this option as the default false, then you should call forceExecutorShutdown() at the appropriate time.
+     * <p>
+     * If using a user-supplied ExecutorService, then this option must remain false.
      * 
      * @param auto  true for automatic shutdown, false for manual via forceExecutorShutdown()
      */
-    public static void setAutoExecutorShutdown(boolean auto) { EventProcessorHost.autoShutdownExecutor = auto; }
+    public static void setAutoExecutorShutdown(boolean auto)
+    {
+    	if ((EventProcessorHost.weOwnExecutor == false) && (auto == true))
+    	{
+    		throw new IllegalArgumentException("Automatic executor shutdown not possible with user-supplied executor");
+    	}
+    	EventProcessorHost.autoShutdownExecutor = auto;
+    }
 
     /**
      * If you do not want to use the automatic shutdown option, then you must call forceExecutorShutdown() during
      * process termination, after the last call to unregisterEventProcessor() has returned. Be sure that you will
      * not need to create any new EventProcessorHost instances, because calling this method means that any new
      * instances will fail when a register* method is called.
+     * <p>
+     * If using a user-supplied ExecutorService, calling this method is not required or recommended.
      * 
      * @param secondsToWait  How long to wait for the ExecutorService to shut down
      * @throws InterruptedException
      */
     public static void forceExecutorShutdown(long secondsToWait) throws InterruptedException
     {
-    	EventProcessorHost.executorService.shutdown();
-    	EventProcessorHost.executorService.awaitTermination(secondsToWait, TimeUnit.SECONDS);
+    	if (EventProcessorHost.weOwnExecutor)
+    	{
+    		EventProcessorHost.executorService.shutdown();
+    		EventProcessorHost.executorService.awaitTermination(secondsToWait, TimeUnit.SECONDS);
+    	}
+    	else
+    	{
+    		// TODO -- should we throw here or just ignore the bad call?
+    	}
     }
 
     

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -62,33 +62,13 @@ public class PartitionContext
         this.lease = lease;
     }
 
-    /**
-     * Updates the offset/sequenceNumber in the PartitionContext with the values in the received EventData object.
-     *  
-     * Since offset is a string it cannot be compared easily, but sequenceNumber is checked. The new sequenceNumber must be
-     * at least the same as the current value or the entire assignment is aborted. It is assumed that if the new sequenceNumber
-     * is equal or greater, the new offset will be as well.
-     * 
-     * @param event  A received EventData with valid offset and sequenceNumber
-     * @throws IllegalArgumentException  If the sequenceNumber in the provided event is less than the current value
-     */
+    @Deprecated
     public void setOffsetAndSequenceNumber(EventData event) throws IllegalArgumentException
     {
     	setOffsetAndSequenceNumber(event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber());
     }
     
-    /**
-     * Updates the offset/sequenceNumber in the PartitionContext.
-     * 
-     * These two values are closely tied and must be updated in an atomic fashion, hence the combined setter.
-     * Since offset is a string it cannot be compared easily, but sequenceNumber is checked. The new sequenceNumber must be
-     * at least the same as the current value or the entire assignment is aborted. It is assumed that if the new sequenceNumber
-     * is equal or greater, the new offset will be as well.
-     * 
-     * @param offset  New offset value
-     * @param sequenceNumber  New sequenceNumber value 
-     * @throws IllegalArgumentException  If the new sequenceNumber is less than the current value
-     */
+    @Deprecated
     public void setOffsetAndSequenceNumber(String offset, long sequenceNumber) throws IllegalArgumentException
     {
     	synchronized (this.offsetSynchronizer)


### PR DESCRIPTION
Add EventProcessorHost constructors which take a blob name prefix when using Azure Storage lease and checkpoint stores.
Add EventProcessorHost constructors which take a user-supplied ExecutorService so EPH can share the application's existing thread pool.
Deprecate PartitionContext.setOffsetAndSequenceNumber for public use.