### PR TITLE
EPH constructor changes, handle nonexistent entities better.

### DIFF
--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -120,8 +120,33 @@ public final class EventProcessorHost
             final String storageConnectionString,
             final String storageContainerName)
     {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param storageBlobPrefix			Prefix used when naming blobs within the storage container.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final String storageBlobPrefix)
+    {
         this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString,
-                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName));
+                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix));
         this.initializeLeaseManager = true;
     }
     

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -34,7 +34,7 @@ public final class EventProcessorHost
     // weOwnExecutor exists to support user-supplied thread pools if we add that feature later.
     // weOwnExecutor is a boxed Boolean so it can be used to synchronize access to these variables.
     // executorRefCount is required because the last host must shut down the thread pool if we own it.
-    private static ExecutorService executorService = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = null;
     private static int executorRefCount = 0;
     private static Boolean weOwnExecutor = true;
     private static boolean autoShutdownExecutor = false;
@@ -96,7 +96,8 @@ public final class EventProcessorHost
             final String eventHubConnectionString,
             final String storageConnectionString)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, new AzureStorageCheckpointLeaseManager(storageConnectionString));
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, new AzureStorageCheckpointLeaseManager(storageConnectionString), 
+        		(ExecutorService)null);
         this.initializeLeaseManager = true;
     }
 
@@ -120,7 +121,32 @@ public final class EventProcessorHost
             final String storageConnectionString,
             final String storageContainerName)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, null);
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, (ExecutorService)null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final ExecutorService executorService)
+    {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, (String)null, executorService);
     }
 
     /**
@@ -145,8 +171,36 @@ public final class EventProcessorHost
             final String storageContainerName,
             final String storageBlobPrefix)
     {
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, storageConnectionString, storageContainerName, storageBlobPrefix,
+        		(ExecutorService)null);
+    }
+
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload adds an argument to specify the Azure Storage container name that will be used to persist leases and checkpoints.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+	 * @param storageConnectionString	Connection string for the Azure Storage account to use for persisting leases and checkpoints.
+     * @param storageContainerName		Azure Storage container name for use by built-in lease and checkpoint manager.
+     * @param storageBlobPrefix			Prefix used when naming blobs within the storage container.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            final String storageConnectionString,
+            final String storageContainerName,
+            final String storageBlobPrefix,
+            final ExecutorService executorService)
+    {
         this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString,
-                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix));
+                new AzureStorageCheckpointLeaseManager(storageConnectionString, storageContainerName, storageBlobPrefix), executorService);
         this.initializeLeaseManager = true;
     }
     
@@ -157,10 +211,12 @@ public final class EventProcessorHost
             final String eventHubPath,
             final String consumerGroupName,
             final String eventHubConnectionString,
-            final AzureStorageCheckpointLeaseManager combinedManager)
+            final AzureStorageCheckpointLeaseManager combinedManager,
+            final ExecutorService executorService)
     {
-        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager);
+        this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager, executorService);
     }
+
 
     /**
      * Create a new host to process events from an Event Hub.
@@ -168,10 +224,10 @@ public final class EventProcessorHost
      * This overload allows the caller to provide their own lease and checkpoint managers to replace the built-in
      * ones based on Azure Storage.
      * 
-     * @param hostName
-     * @param eventHubPath
-     * @param consumerGroupName
-     * @param eventHubConnectionString
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
      * @param checkpointManager			Implementation of ICheckpointManager, to be replacement checkpoint manager.
      * @param leaseManager				Implementation of ILeaseManager, to be replacement lease manager.
      */
@@ -183,6 +239,32 @@ public final class EventProcessorHost
             ICheckpointManager checkpointManager,
             ILeaseManager leaseManager)
     {
+    	this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, checkpointManager, leaseManager, null);
+    }
+    
+    /**
+     * Create a new host to process events from an Event Hub.
+     * 
+     * This overload allows the caller to provide their own lease and checkpoint managers to replace the built-in
+     * ones based on Azure Storage, and to provide an executor service.
+     * 
+     * @param hostName		A name for this event processor host. See method notes.
+	 * @param eventHubPath 				Specifies the Event Hub to receive events from.
+	 * @param consumerGroupName			The name of the consumer group to use when receiving from the Event Hub.
+	 * @param eventHubConnectionString	Connection string for the Event Hub to receive from.
+     * @param checkpointManager			Implementation of ICheckpointManager, to be replacement checkpoint manager.
+     * @param leaseManager				Implementation of ILeaseManager, to be replacement lease manager.
+     * @param executorService			User-supplied thread executor, or null to use EventProcessorHost-internal executor.
+     */
+    public EventProcessorHost(
+            final String hostName,
+            final String eventHubPath,
+            final String consumerGroupName,
+            final String eventHubConnectionString,
+            ICheckpointManager checkpointManager,
+            ILeaseManager leaseManager,
+            ExecutorService executorService)
+    {
     	EventProcessorHost.TRACE_LOGGER.setLevel(Level.SEVERE);
     	
         this.hostName = hostName;
@@ -191,15 +273,41 @@ public final class EventProcessorHost
         this.eventHubConnectionString = eventHubConnectionString;
         this.checkpointManager = checkpointManager;
         this.leaseManager = leaseManager;
-        
-        if (EventProcessorHost.weOwnExecutor)
+
+        synchronized(EventProcessorHost.weOwnExecutor)
         {
-	        synchronized(EventProcessorHost.weOwnExecutor)
+	        if (EventProcessorHost.executorService != null)
 	        {
-	        	EventProcessorHost.executorRefCount++;
+	        	// An EventProcessorHost has already been instantiated in this process.
+	        	// Ignore any settings provided, just use the existing ExecutorService and
+	        	// related settings.
+	        	
+	        	// If using EventProcessorHost internal ExecutorService, increase the refcount.
+	        	if (EventProcessorHost.weOwnExecutor)
+	        	{
+	        		EventProcessorHost.executorRefCount++;
+	        	}
+	        }
+	        else
+	        {
+		        if (executorService != null)
+		        {
+		        	// User has supplied an ExecutorService, so use that.
+		        	EventProcessorHost.weOwnExecutor = false;
+		        	EventProcessorHost.executorService = executorService;
+		        	// We don't own it so refcount is meaningless.
+		        	// Make sure that auto shutdown is false!
+		        	EventProcessorHost.autoShutdownExecutor = false;
+		        }
+		        else
+		        {
+		        	EventProcessorHost.weOwnExecutor = true;
+		        	EventProcessorHost.executorService = Executors.newCachedThreadPool();
+		        	EventProcessorHost.executorRefCount++;
+		        }
 	        }
         }
-
+        
         this.partitionManager = new PartitionManager(this);
         
         logWithHost(Level.INFO, "New EventProcessorHost created");
@@ -248,6 +356,7 @@ public final class EventProcessorHost
      * class EventProcessor implements IEventProcessor { ... }
      * EventProcessorHost host = new EventProcessorHost(...);
      * Future foo = host.registerEventProcessor(EventProcessor.class);
+     * foo.get();
      * </pre>
      *  
      * @param eventProcessorType	Class that implements IEventProcessor.
@@ -368,12 +477,13 @@ public final class EventProcessorHost
     // PartitionManager calls this after all shutdown tasks have been submitted to the ExecutorService.
     void stopExecutor()
     {
-        if (EventProcessorHost.weOwnExecutor && EventProcessorHost.autoShutdownExecutor)
+        if (EventProcessorHost.weOwnExecutor)
         {
         	synchronized(EventProcessorHost.weOwnExecutor)
         	{
         		EventProcessorHost.executorRefCount--;
-        		if (EventProcessorHost.executorRefCount <= 0)
+        		
+        		if ((EventProcessorHost.executorRefCount <= 0) && EventProcessorHost.autoShutdownExecutor)
         		{
         			// It is OK to call shutdown() here even though threads are still running.
         			// Shutdown() causes the executor to stop accepting new tasks, but existing tasks will
@@ -393,24 +503,42 @@ public final class EventProcessorHost
      * only ever call unregisterEventProcess() when the process is shutting down.
      * <p>
      * If you leave this option as the default false, then you should call forceExecutorShutdown() at the appropriate time.
+     * <p>
+     * If using a user-supplied ExecutorService, then this option must remain false.
      * 
      * @param auto  true for automatic shutdown, false for manual via forceExecutorShutdown()
      */
-    public static void setAutoExecutorShutdown(boolean auto) { EventProcessorHost.autoShutdownExecutor = auto; }
+    public static void setAutoExecutorShutdown(boolean auto)
+    {
+    	if ((EventProcessorHost.weOwnExecutor == false) && (auto == true))
+    	{
+    		throw new IllegalArgumentException("Automatic executor shutdown not possible with user-supplied executor");
+    	}
+    	EventProcessorHost.autoShutdownExecutor = auto;
+    }
 
     /**
      * If you do not want to use the automatic shutdown option, then you must call forceExecutorShutdown() during
      * process termination, after the last call to unregisterEventProcessor() has returned. Be sure that you will
      * not need to create any new EventProcessorHost instances, because calling this method means that any new
      * instances will fail when a register* method is called.
+     * <p>
+     * If using a user-supplied ExecutorService, calling this method is not required or recommended.
      * 
      * @param secondsToWait  How long to wait for the ExecutorService to shut down
      * @throws InterruptedException
      */
     public static void forceExecutorShutdown(long secondsToWait) throws InterruptedException
     {
-    	EventProcessorHost.executorService.shutdown();
-    	EventProcessorHost.executorService.awaitTermination(secondsToWait, TimeUnit.SECONDS);
+    	if (EventProcessorHost.weOwnExecutor)
+    	{
+    		EventProcessorHost.executorService.shutdown();
+    		EventProcessorHost.executorService.awaitTermination(secondsToWait, TimeUnit.SECONDS);
+    	}
+    	else
+    	{
+    		// TODO -- should we throw here or just ignore the bad call?
+    	}
     }
 
     

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
@@ -74,7 +74,7 @@ public interface ILeaseManager
      * 
      * @return  Iterable list of lease info.
      */
-    public Iterable<Future<Lease>> getAllLeases();
+    public Iterable<Future<Lease>> getAllLeases() throws Exception;
 
     /**
      * Create in the store the lease info for the given partition, if it does not exist. Do nothing if it does exist

--- a/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/java/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -62,33 +62,13 @@ public class PartitionContext
         this.lease = lease;
     }
 
-    /**
-     * Updates the offset/sequenceNumber in the PartitionContext with the values in the received EventData object.
-     *  
-     * Since offset is a string it cannot be compared easily, but sequenceNumber is checked. The new sequenceNumber must be
-     * at least the same as the current value or the entire assignment is aborted. It is assumed that if the new sequenceNumber
-     * is equal or greater, the new offset will be as well.
-     * 
-     * @param event  A received EventData with valid offset and sequenceNumber
-     * @throws IllegalArgumentException  If the sequenceNumber in the provided event is less than the current value
-     */
+    @Deprecated
     public void setOffsetAndSequenceNumber(EventData event) throws IllegalArgumentException
     {
     	setOffsetAndSequenceNumber(event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber());
     }
     
-    /**
-     * Updates the offset/sequenceNumber in the PartitionContext.
-     * 
-     * These two values are closely tied and must be updated in an atomic fashion, hence the combined setter.
-     * Since offset is a string it cannot be compared easily, but sequenceNumber is checked. The new sequenceNumber must be
-     * at least the same as the current value or the entire assignment is aborted. It is assumed that if the new sequenceNumber
-     * is equal or greater, the new offset will be as well.
-     * 
-     * @param offset  New offset value
-     * @param sequenceNumber  New sequenceNumber value 
-     * @throws IllegalArgumentException  If the new sequenceNumber is less than the current value
-     */
+    @Deprecated
     public void setOffsetAndSequenceNumber(String offset, long sequenceNumber) throws IllegalArgumentException
     {
     	synchronized (this.offsetSynchronizer)

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/CheckpointManagerTest.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/CheckpointManagerTest.java
@@ -261,10 +261,8 @@ public class CheckpointManagerTest
 		}
 		
 		// Host name needs to be unique per host so use index. Event hub should be the same for all hosts in a test, so use the supplied suffix.
-		String syntactiallyCorrectDummyConnectionString =
-				"Endpoint=sb://notreal.servicebus.windows.net/;SharedAccessKeyName=notreal;SharedAccessKey=NOTREALNOTREALNOTREALNOTREALNOTREALNOTREALN=;EntityPath=NOTREAL" + suffix;
     	EventProcessorHost host = new EventProcessorHost("dummyHost" + String.valueOf(index), "NOTREAL" + suffix,
-    			EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, syntactiallyCorrectDummyConnectionString, checkpointMgr, leaseMgr);
+    			EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, TestUtilities.syntacticallyCorrectDummyConnectionString + suffix, checkpointMgr, leaseMgr);
     	
     	
     	try

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
@@ -28,7 +28,6 @@ class DummyPump extends Pump
 	
 	void fastCleanup()
 	{
-		System.out.println("Host " + this.host.getHostName() + " fast cleanup");
 		HashSet<String> capturedList = new HashSet<String>(this.pumps); // avoid deadlock!
 		for (String p : capturedList)
 		{
@@ -36,7 +35,6 @@ class DummyPump extends Pump
 			try
 			{
 				l = this.host.getLeaseManager().getLease(p).get();
-				//System.out.println("Host " + this.host.getHostName() + " cleanup retrieved lease for " + p);
 			} 
 			catch (InterruptedException | ExecutionException e)
 			{
@@ -48,7 +46,7 @@ class DummyPump extends Pump
 				// Another host has stolen this lease.
 				try
 				{
-					System.out.println("Steal detected, host " + this.host.getHostName() + " removing " + p);
+					TestUtilities.log("Steal detected, host " + this.host.getHostName() + " removing " + p);
 					removePump(p, CloseReason.LeaseLost).get();
 				}
 				catch (InterruptedException | ExecutionException e)
@@ -57,7 +55,7 @@ class DummyPump extends Pump
 			}
 			else
 			{
-				//System.out.println("Host " + this.host.getHostName() + " cleanup still own " + p);
+				
 			}
 		}
 	}

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/EPHConstructorTests.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/EPHConstructorTests.java
@@ -1,0 +1,305 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class EPHConstructorTests extends TestBase
+{
+	@Test
+	public void conflictingEventHubPathsTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("ConflictingEventHubPaths");
+		settings.inEntityDoesNotExist = true;
+		settings.inoutEPHConstructorArgs.setEHPath("thisisdifferentfromtheconnectionstring", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			if ((e.getMessage() != null) && (e.getMessage().compareTo("Provided EventHub path in eventHubPath parameter conflicts with the path in provided EventHub connection string") == 0))
+			{
+				TestUtilities.log("Got expected exception\n");
+			}
+			else
+			{
+				throw e;
+			}
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void missingEventHubPathTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("MissingEventHubPath");
+		settings.inEntityDoesNotExist = true;
+		settings.inoutEPHConstructorArgs.setEHPath("", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE_AND_REPLACE);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			if ((e.getMessage() != null) && (e.getMessage().compareTo("Provide EventHub entity path in either eventHubPath argument or in eventHubConnectionString") == 0))
+			{
+				TestUtilities.log("Got expected exception\n");
+			}
+			else
+			{
+				throw e;
+			}
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullHostNameTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullHostName");
+		settings.inoutEPHConstructorArgs.setHostName(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void emptyHostNameTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EmptyHostName");
+		settings.inoutEPHConstructorArgs.setHostName("");
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullConsumerGroupNameTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullConsumerGroupName");
+		settings.inoutEPHConstructorArgs.setConsumerGroupName(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void emptyConsumerGroupNameTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EmptyConsumerGroupName");
+		settings.inoutEPHConstructorArgs.setConsumerGroupName("");
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullEHConnectionStringTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullEHConnectionString");
+		settings.inoutEPHConstructorArgs.setEHConnection(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void emptyEHConnectionStringTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EmptyEHConnectionString");
+		settings.inoutEPHConstructorArgs.setEHConnection("");
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void ehPathOnlySeparateTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EHPathOnlySeparate");
+		settings.inoutEPHConstructorArgs.removePathFromEHConnection();
+		
+		try
+		{
+			settings = testSetup(settings);
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void ehPathOnlyInConnStringTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EHPathOnlyInConnString");
+		settings.inoutEPHConstructorArgs.setEHPath("", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE);
+		
+		try
+		{
+			settings = testSetup(settings);
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullCheckpointManagerTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullCheckpointManager");
+		settings.inoutEPHConstructorArgs.setCheckpointManager(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullLeaseManagerTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullLeaseManager");
+		settings.inoutEPHConstructorArgs.setLeaseManager(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void nullStorageConnectionStringTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NullStorageConnectionString");
+		settings.inoutEPHConstructorArgs.setStorageConnection(null);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void emptyStorageConnectionStringTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("EmptyStorageConnectionString");
+		settings.inoutEPHConstructorArgs.setStorageConnection("");
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (IllegalArgumentException e)
+		{
+			TestUtilities.log("Got expected exception");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	// TODO
+	// @Test
+	// public void verifyStorageContainerNameTest() throws Exception
+	// Uses Storage APIs to check that the expected container has been created.
+	
+	// TODO
+	// @Test
+	// public void verifyStorageBlobPrefixTest() throws Exception
+	// Uses Storage APIs to check that the blobs have the expected prefix in their names
+}

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
@@ -113,7 +113,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     }
 
     @Override
-    public Iterable<Future<Lease>> getAllLeases()
+    public Iterable<Future<Lease>> getAllLeases() throws Exception
     {
         ArrayList<Future<Lease>> leases = new ArrayList<Future<Lease>>();
         Iterable<String> partitionIds = this.host.getPartitionManager().getPartitionIds();
@@ -383,7 +383,7 @@ public class InMemoryLeaseManager implements ILeaseManager
         	InMemoryLease leaseInStore = getLease(partitionId);
             try
             {
-				if (leaseInStore.isExpired() || (leaseInStore.getOwner() == null) || (leaseInStore.getOwner().length() == 0))
+				if (leaseInStore.isExpired() || (leaseInStore.getOwner() == null) || leaseInStore.getOwner().isEmpty())
 				{
 					leaseInStore.setOwner(newOwner);
 	                leaseInStore.setExpirationTime(System.currentTimeMillis() + InMemoryLeaseManager.leaseDurationInMillieconds);

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/LeaseManagerTest.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/LeaseManagerTest.java
@@ -284,10 +284,8 @@ public class LeaseManagerTest
 		}
 		
 		// Host name needs to be unique per host so use index. Event hub should be the same for all hosts in a test, so use the supplied suffix.
-		String syntactiallyCorrectDummyConnectionString =
-				"Endpoint=sb://notreal.servicebus.windows.net/;SharedAccessKeyName=notreal;SharedAccessKey=NOTREALNOTREALNOTREALNOTREALNOTREALNOTREALN=;EntityPath=NOTREAL" + suffix;
     	EventProcessorHost host = new EventProcessorHost("dummyHost" + String.valueOf(index), "NOTREAL" + suffix,
-    			EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, syntactiallyCorrectDummyConnectionString, checkpointMgr, leaseMgr);
+    			EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, TestUtilities.syntacticallyCorrectDummyConnectionString + suffix, checkpointMgr, leaseMgr);
     	
     	try
     	{

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
@@ -1,0 +1,165 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+
+public class PerTestSettings
+{
+	// Properties which are inputs to test setup. Constructor sets up defaults, except for testName.
+	private String inTestName;
+	EventProcessorOptions inOptions; // can be null
+	boolean inDoCheckpoint;
+	boolean inEntityDoesNotExist; // Prevents test code from doing certain checks that would fail on nonexistence before reaching product code.
+	
+	PerTestSettings(String testName)
+	{
+		this.inTestName = testName;
+		this.inOptions = EventProcessorOptions.getDefaultOptions();
+		this.inDoCheckpoint = false;
+		this.inEntityDoesNotExist = false;
+		
+		this.inoutEPHConstructorArgs = new EPHConstructorArgs();
+	}
+	
+	String getTestName() { return this.inTestName; }
+
+	// In-out properties: may be set before test setup and then changed by setup.
+	final EPHConstructorArgs inoutEPHConstructorArgs;
+	
+	// Output properties: any value set before test setup is ignored. The real value is
+	// established during test setup.
+	RealEventHubUtilities outUtils;
+	String outTelltale;
+	ArrayList<String> outPartitionIds;
+	PrefabGeneralErrorHandler outGeneralErrorHandler;
+	PrefabProcessorFactory outProcessorFactory;
+	EventProcessorHost outHost;
+
+	
+	class EPHConstructorArgs
+	{
+		static final int HOST_OVERRIDE = 0x0001;
+		static final int EH_PATH_OVERRIDE = 0x0002;
+		static final int EH_PATH_REPLACE_IN_CONNECTION = 0x0004;
+		static final int EH_PATH_OVERRIDE_AND_REPLACE = EH_PATH_OVERRIDE | EH_PATH_REPLACE_IN_CONNECTION;
+		static final int CONSUMER_GROUP_OVERRIDE = 0x0008;
+		static final int EH_CONNECTION_OVERRIDE = 0x0010;
+		static final int EH_CONNECTION_REMOVE_PATH = 0x0020;
+		static final int STORAGE_CONNECTION_OVERRIDE = 0x0040;
+		static final int STORAGE_CONTAINER_OVERRIDE = 0x0080;
+		static final int STORAGE_BLOB_PREFIX_OVERRIDE = 0x0100;
+		static final int EXECUTOR_OVERRIDE = 0x0200;
+		static final int CHECKPOINT_MANAGER_OVERRIDE = 0x0400;
+		static final int LEASE_MANAGER_OVERRIDE = 0x0800;
+		static final int EXPLICIT_MANAGER = CHECKPOINT_MANAGER_OVERRIDE | LEASE_MANAGER_OVERRIDE;
+		
+		private int flags;
+		
+		private String hostName;
+		private String ehPath;
+		private String consumerGroupName;
+		private String ehConnection;
+		private String storageConnection;
+		private String storageContainerName;
+		private String storageBlobPrefix;
+		private ExecutorService executor;
+		private ICheckpointManager checkpointManager;
+		private ILeaseManager leaseManager;
+		
+		EPHConstructorArgs()
+		{
+			this.flags = 0;
+			
+			this.hostName = null;
+			this.ehPath = null;
+			this.consumerGroupName = null;
+			this.ehConnection = null;
+			this.storageConnection = null;
+			this.storageContainerName = null;
+			this.storageBlobPrefix = null;
+			this.executor = null;
+			this.checkpointManager = null;
+			this.leaseManager = null;
+		}
+		
+		int getFlags() { return this.flags; }
+		boolean isFlagSet(int testFlag) { return ((this.flags & testFlag) != 0); }
+		
+		void setHostName(String hostName)
+		{
+			this.hostName = hostName;
+			this.flags |= HOST_OVERRIDE;
+		}
+		String getHostName() { return this.hostName; }
+		
+		void setEHPath(String ehPath, int flags)
+		{
+			this.ehPath = ehPath;
+			this.flags |= (flags & EH_PATH_OVERRIDE_AND_REPLACE);
+		}
+		String getEHPath() { return this.ehPath; }
+		
+		void setConsumerGroupName(String consumerGroupName)
+		{
+			this.consumerGroupName = consumerGroupName;
+			this.flags |= CONSUMER_GROUP_OVERRIDE;
+		}
+		String getConsumerGroupName() { return this.consumerGroupName; }
+		
+		void setEHConnection(String ehConnection)
+		{
+			this.ehConnection = ehConnection;
+			this.flags |= EH_CONNECTION_OVERRIDE;
+		}
+		void removePathFromEHConnection() { this.flags |= EH_CONNECTION_REMOVE_PATH; }
+		String getEHConnection() { return this.ehConnection; }
+		
+		void setStorageConnection(String storageConnection)
+		{
+			this.storageConnection = storageConnection;
+			this.flags |= STORAGE_CONNECTION_OVERRIDE;
+		}
+		String getStorageConnection() { return this.storageConnection; }
+		
+		void setStorageContainerName(String storageContainerName)
+		{
+			this.storageContainerName = storageContainerName;
+			this.flags |= STORAGE_CONTAINER_OVERRIDE;
+		}
+		void setDefaultStorageContainerName(String defaultStorageContainerName)
+		{
+			this.storageContainerName = defaultStorageContainerName;
+		}
+		String getStorageContainerName() { return this.storageContainerName; }
+		
+		void setStorageBlobPrefix(String storageBlobPrefix)
+		{
+			this.storageBlobPrefix = storageBlobPrefix;
+			this.flags |= STORAGE_BLOB_PREFIX_OVERRIDE;
+		}
+		String getStorageBlobPrefix() { return this.storageBlobPrefix; }
+		
+		void setExecutor(ExecutorService executor)
+		{
+			this.executor = executor;
+			this.flags |= EXECUTOR_OVERRIDE;
+		}
+		ExecutorService getExecutor() { return this.executor; }
+		
+		boolean useExplicitManagers() { return ((this.flags & EXPLICIT_MANAGER) != 0); }
+		
+		void setCheckpointManager(ICheckpointManager checkpointManager)
+		{
+			this.checkpointManager = checkpointManager;
+			this.flags |= CHECKPOINT_MANAGER_OVERRIDE;
+		}
+		ICheckpointManager getCheckpointMananger() { return this.checkpointManager; }
+		
+		void setLeaseManager(ILeaseManager leaseManager)
+		{
+			this.leaseManager = leaseManager;
+			this.flags |= LEASE_MANAGER_OVERRIDE;
+		}
+		ILeaseManager getLeaseManager() { return this.leaseManager; }
+	}
+}

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
@@ -13,6 +13,7 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	private String telltale;
 	private boolean doCheckpoint;
 	private boolean doMarker;
+	private boolean logEveryMessage;
 	
 	private ArrayList<String> errors = new ArrayList<String>();
 	private HashMap<String, Boolean> foundTelltale = new HashMap<String, Boolean>(); 
@@ -20,9 +21,15 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	
 	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker)
 	{
+		this(telltale, doCheckpoint, doMarker, false);
+	}
+	
+	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker, boolean logEveryMessage)
+	{
 		this.telltale = telltale;
 		this.doCheckpoint = doCheckpoint;
 		this.doMarker = doMarker;
+		this.logEveryMessage = logEveryMessage;
 	}
 	
 	void putError(String error)
@@ -69,6 +76,6 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	@Override
 	public IEventProcessor createEventProcessor(PartitionContext context) throws Exception
 	{
-		return new PrefabEventProcessor(this, this.telltale, this.doCheckpoint, this.doMarker);
+		return new PrefabEventProcessor(this, this.telltale, this.doCheckpoint, this.doMarker, this.logEveryMessage);
 	}
 }

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
@@ -1,0 +1,97 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.microsoft.azure.servicebus.IllegalEntityException;
+
+public class SadPathTests extends TestBase
+{
+	@Test
+	public void noSuchEventHubTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NoSuchEventHub");
+		settings.inEntityDoesNotExist = true;
+		settings.inoutEPHConstructorArgs.setEHPath("thereisnoeventhubwiththisname", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE_AND_REPLACE);
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (ExecutionException e)
+		{
+			Throwable inner = e.getCause();
+			if ((inner != null) && (inner instanceof IllegalEntityException))
+			{
+				TestUtilities.log("Got expected IllegalEntityException\n");
+			}
+			else
+			{
+				throw e;
+			}
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void noSuchConsumerGroupTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("NoSuchConsumerGroup");
+		settings.inEntityDoesNotExist = true;
+		settings.inoutEPHConstructorArgs.setConsumerGroupName("thereisnoconsumergroupwiththisname");
+		try
+		{
+			settings = testSetup(settings);
+			fail("No exception occurred");
+		}
+		catch (ExecutionException e)
+		{
+			Throwable inner = e.getCause();
+			if ((inner != null) && (inner instanceof EPHConfigurationException))
+			{
+				if ((inner.getMessage() != null) && (inner.getMessage().compareTo("Consumer group does not exist") == 0))
+				{
+					TestUtilities.log("Got expected exception\n");
+				}
+				else
+				{
+					throw e;
+				}
+			}
+			else
+			{
+				throw e;
+			}
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void secondRegisterFailsTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("SecondRegisterFails");
+		settings = testSetup(settings);
+		
+		try
+		{
+			settings.outHost.registerEventProcessorFactory(settings.outProcessorFactory, settings.inOptions).get();
+			fail("No exception occurred");
+		}
+		catch (IllegalStateException e)
+		{
+			TestUtilities.log("Got expected exception\n");
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+}

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
@@ -8,29 +8,28 @@ package com.microsoft.azure.eventprocessorhost;
 import static org.junit.Assert.*;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import org.junit.AfterClass;
 import org.junit.Test;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
-//import com.microsoft.azure.servicebus.DebugThread;
-import com.microsoft.azure.servicebus.ServiceBusException;
 
-public class SmokeTest
+public class SmokeTest extends TestBase
 {
-	//@Test
+	/*
+	@Test
 	public void smokeTest() throws Exception
 	{
-		PerTestSettings settings = testSetup("smokeTest");
+		PerTestSettings settings = new PerTestSettings("smoketest");
+		//settings.inBlobPrefix = "testprefix";
+		settings = testSetup(settings); 
 
-		settings.utils.sendToAny(settings.telltale);
+		settings.outUtils.sendToAny(settings.outTelltale);
 		waitForTelltale(settings);
 
 		testFinish(settings, SmokeTest.ANY_NONZERO_COUNT);
@@ -51,17 +50,43 @@ public class SmokeTest
 		// The purpose of running a second iteration is to look for bugs that occur when leases have been
 		// created and persisted but checkpoints have not, so it is vital that the second iteration uses the
 		// same storage container.
-		receiveFromNowIteration(storedNow, 2, 2, firstSettings.storageContainerName);
+		receiveFromNowIteration(storedNow, 2, 2, firstSettings.inoutStorageContainerName);
 	}
 	
 	private PerTestSettings receiveFromNowIteration(final Instant storedNow, int iteration, int expectedMessages, String containerName) throws Exception
 	{
-		EventProcessorOptions options = EventProcessorOptions.getDefaultOptions();
-		options.setInitialOffsetProvider((partitionId) -> { return storedNow; });
-		PerTestSettings settings = testSetup("receiveFromNowTest-iter-" + iteration, options, containerName);
+		PerTestSettings settings = new PerTestSettings("receiveFromNowTest-iter-" + iteration);
+		settings.inForcedContainerName = containerName;
+		settings.inOptions.setInitialOffsetProvider((partitionId) -> { return storedNow; });
+		settings = testSetup(settings);
 
-		settings.utils.sendToAny(settings.telltale);
+		settings.outUtils.sendToAny(settings.outTelltale);
 		waitForTelltale(settings);
+
+		testFinish(settings, expectedMessages);
+		
+		return settings;
+	}
+	
+	//@Test
+	public void receiveFromCheckpoint() throws Exception
+	{
+		PerTestSettings firstSettings = receiveFromCheckpointIteration(1, SmokeTest.ANY_NONZERO_COUNT, null);
+		receiveFromCheckpointIteration(2, firstSettings.outPartitionIds.size(), firstSettings.inoutStorageContainerName);
+	}
+
+	private PerTestSettings receiveFromCheckpointIteration(int iteration, int expectedMessages, String containerName) throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("receiveFromCkptTest-iter-" + iteration);
+		settings.inForcedContainerName = containerName;
+		settings.inDoCheckpoint = true;
+		settings = testSetup(settings);
+
+		for (String id: settings.outPartitionIds)
+		{
+			settings.outUtils.sendToPartition(id, settings.outTelltale);
+			waitForTelltale(settings, id);
+		}
 
 		testFinish(settings, expectedMessages);
 		
@@ -71,39 +96,39 @@ public class SmokeTest
 	//@Test
 	public void receiveAllPartitionsTest() throws Exception
 	{
-		EventProcessorOptions options = EventProcessorOptions.getDefaultOptions();
-		options.setInitialOffsetProvider((partitionId) -> { return Instant.now(); });
-		PerTestSettings settings = testSetup("receiveAllPartitionsTest", options);
+		PerTestSettings settings = new PerTestSettings("receiveAllPartitionsTest");
+		settings.inOptions.setInitialOffsetProvider((partitionId) -> { return Instant.now(); });
+		settings = testSetup(settings);
 
 		final int maxGeneration = 10;
 		for (int generation = 0; generation < maxGeneration; generation++)
 		{
-			for (String id : settings.partitionIds)
+			for (String id : settings.outPartitionIds)
 			{
-				settings.utils.sendToPartition(id, "receiveAllPartitionsTest-" + id + "-" + generation);
+				settings.outUtils.sendToPartition(id, "receiveAllPartitionsTest-" + id + "-" + generation);
 			}
 			System.out.println("Generation " + generation + " sent");
 		}
-		for (String id : settings.partitionIds)
+		for (String id : settings.outPartitionIds)
 		{
-			settings.utils.sendToPartition(id, settings.telltale);
+			settings.outUtils.sendToPartition(id, settings.outTelltale);
 			System.out.println("Telltale " + id + " sent");
 		}
-		for (String id : settings.partitionIds)
+		for (String id : settings.outPartitionIds)
 		{
 			waitForTelltale(settings, id);
 		}
 		
-		testFinish(settings, (settings.partitionIds.size() * (maxGeneration + 1))); // +1 for the telltales
+		testFinish(settings, (settings.outPartitionIds.size() * (maxGeneration + 1))); // +1 for the telltales
 	}
 	
-	@Test
+	//@Test
 	public void conflictingHosts() throws Exception
 	{
 		System.out.println("conflictingHosts starting");
 		
 		RealEventHubUtilities utils = new RealEventHubUtilities();
-		utils.setup();
+		utils.setup(-1);
 		
 		String telltale = "conflictingHosts-telltale-" + EventProcessorHost.safeCreateUUID();
 		String conflictingName = "conflictingHosts-NOTSAFE";
@@ -141,28 +166,100 @@ public class SmokeTest
 			Thread.sleep(100);
 		}
 	}
+	*/
 	
 	//@Test
 	public void rawEpochStealing() throws Exception
 	{
 		RealEventHubUtilities utils = new RealEventHubUtilities();
-		utils.setup();
+		utils.setup(-1);
 
 		int clientSerialNumber = 0;
 		while (true)
 		{
-			//DebugThread.printThreadStatuses();
+			Thread[] blah = new Thread[Thread.activeCount() + 10];
+			int actual = Thread.enumerate(blah); 
+			if (actual >= blah.length)
+			{
+				System.out.println("Lost some threads");
+			}
+			int parkedCount = 0;
+			String selectingList = "";
+			boolean display = true;
+			for (int i = 0; i < actual; i++)
+			{
+				display = true;
+				StackTraceElement[] bloo = blah[i].getStackTrace();
+				String show = "nostack";
+				if (bloo.length > 0)
+				{
+					show = bloo[0].getClassName() + "." + bloo[0].getMethodName();
+					if (show.compareTo("sun.misc.Unsafe.park") == 0)
+					{
+						parkedCount++;
+						display = false;
+					}
+					else if (show.compareTo("sun.nio.ch.WindowsSelectorImpl$SubSelector.poll0") == 0)
+					{
+						selectingList += (" " + blah[i].getId());
+						display = false;
+					}
+				}
+				if (display)
+				{
+					System.out.print(" " + blah[i].getId() + ":" + show);
+				}
+			}
+			System.out.println("\nParked: " + parkedCount + "  SELECTING: " + selectingList);
 			
 			System.out.println("Client " + clientSerialNumber + " starting");
 			EventHubClient client = EventHubClient.createFromConnectionStringSync(utils.getConnectionString().toString());
 			PartitionReceiver receiver =
 					client.createEpochReceiver(utils.getConsumerGroup(), "0", PartitionReceiver.START_OF_STREAM, 1).get();
+
+			boolean useReceiveHandler = false;
 			
-			Blah b = new Blah(clientSerialNumber++, receiver, client);
-			receiver.setReceiveHandler(b);
+			if (useReceiveHandler)
+			{
+				Blah b = new Blah(clientSerialNumber++, receiver, client);
+				receiver.setReceiveHandler(b).get();
+				// wait for messages to start flowing
+				b.waitForReceivedMessages().get();
+			}
+			else
+			{
+				receiver.receiveSync(1);
+				System.out.println("Received a message");
+			}
 			
-			// wait for messages to start flowing
-			b.waitForReceivedMessages().get();
+			// Enable these lines to avoid overlap
+			/* */
+			try
+			{
+				System.out.println("Non-overlap close of PartitionReceiver");
+				if (useReceiveHandler)
+				{
+					receiver.setReceiveHandler(null).get();
+				}
+				receiver.close().get();
+			}
+			catch (InterruptedException | ExecutionException e)
+			{
+				System.out.println("Client " + clientSerialNumber + " failed while closing PartitionReceiver: " + e.toString());
+			}
+			try
+			{
+				System.out.println("Non-overlap close of EventHubClient");
+				client.close().get();
+			}
+			catch (InterruptedException | ExecutionException e)
+			{
+				System.out.println("Client " + clientSerialNumber + " failed while closing EventHubClient: " + e.toString());
+			}
+			System.out.println("Client " + clientSerialNumber + " closed");
+			/* */
+
+			System.out.println("Threads: " + Thread.activeCount());
 		}
 	}
 	
@@ -203,134 +300,24 @@ public class SmokeTest
 		public void onError(Throwable error)
 		{
 			System.out.println("Client " + this.clientSerialNumber + " got " + error.toString());
-			this.receiver.close();
-			this.client.close();
+			try
+			{
+				this.receiver.close().get();
+			}
+			catch (InterruptedException | ExecutionException e)
+			{
+				System.out.println("Client " + this.clientSerialNumber + " failed while closing PartitionReceiver: " + e.toString());
+			}
+			try
+			{
+				this.client.close().get();
+			}
+			catch (InterruptedException | ExecutionException e)
+			{
+				System.out.println("Client " + this.clientSerialNumber + " failed while closing EventHubClient: " + e.toString());
+			}
 			System.out.println("Client " + this.clientSerialNumber + " closed");
 		}
 		
-	}
-	
-	PerTestSettings testSetup(String testName) throws Exception
-	{
-		return testSetup(testName, EventProcessorOptions.getDefaultOptions());
-	}
-	
-	PerTestSettings testSetup(String testName, EventProcessorOptions options) throws Exception
-	{
-		return testSetup(testName, options, null);
-	}
-	
-	PerTestSettings testSetup(String testName, EventProcessorOptions options, String forcedStorageContainerName) throws Exception
-	{
-		System.out.println(testName + " starting");
-		
-		PerTestSettings settings = new PerTestSettings(testName);
-		
-		settings.utils = new RealEventHubUtilities();
-		settings.partitionIds = settings.utils.setup();
-
-		settings.telltale = settings.testName + "-telltale-" + EventProcessorHost.safeCreateUUID();
-		settings.general = new PrefabGeneralErrorHandler();
-		settings.factory = new PrefabProcessorFactory(settings.telltale, false, true);
-		
-		settings.storageContainerName = (forcedStorageContainerName != null) ? forcedStorageContainerName : 
-			(settings.testName.toLowerCase() + "-" + EventProcessorHost.safeCreateUUID());
-		settings.host = new EventProcessorHost(settings.testName + "-1", settings.utils.getConnectionString().getEntityPath(),
-				settings.utils.getConsumerGroup(), settings.utils.getConnectionString().toString(),
-				TestUtilities.getStorageConnectionString(), settings.storageContainerName);
-		options.setExceptionNotification(settings.general);
-		settings.host.registerEventProcessorFactory(settings.factory, options).get();
-		
-		Thread.sleep(5000);
-		
-		return settings;
-	}
-	
-	void waitForTelltale(PerTestSettings settings) throws InterruptedException
-	{
-		for (int i = 0; i < 100; i++)
-		{
-			if (settings.factory.getAnyTelltaleFound())
-			{
-				System.out.println("Telltale found");
-				break;
-			}
-			Thread.sleep(5000);
-			System.out.println();
-		}
-	}
-	
-	void waitForTelltale(PerTestSettings settings, String partitionId) throws InterruptedException
-	{
-		for (int i = 0; i < 100; i++)
-		{
-			if (settings.factory.getTelltaleFound(partitionId))
-			{
-				System.out.println("Telltale " + partitionId + " found");
-				break;
-			}
-			Thread.sleep(5000);
-			System.out.println();
-		}
-	}
-
-	// if expectedMessages is -1, just check for > 0
-	final static int ANY_NONZERO_COUNT = -1;
-	void testFinish(PerTestSettings settings, int expectedMessages) throws InterruptedException, ExecutionException, ServiceBusException
-	{
-		settings.host.unregisterEventProcessor();
-		System.out.println("Events received: " + settings.factory.getEventsReceivedCount());
-		if (expectedMessages < 0)
-		{
-			assertTrue("no messages received", settings.factory.getEventsReceivedCount() > 0);
-		}
-		else
-		{
-			assertEquals("wrong number of messages received", expectedMessages, settings.factory.getEventsReceivedCount());
-		}
-		
-		assertTrue("telltale message was not found", settings.factory.getAnyTelltaleFound());
-		assertEquals("partition errors seen", 0, settings.factory.getErrors().size());
-		assertEquals("general errors seen", 0, settings.general.getErrors().size());
-		for (String err : settings.factory.getErrors())
-		{
-			System.out.println(err);
-		}
-		for (String err : settings.general.getErrors())
-		{
-			System.out.println(err);
-		}
-		
-		settings.utils.shutdown();
-		
-		System.out.println(settings.testName + " ended");
-	}
-	
-	@AfterClass
-	public static void allTestFinish()
-	{
-		try
-		{
-			EventProcessorHost.forceExecutorShutdown(20);
-		}
-		catch (InterruptedException e)
-		{
-			System.out.println("forceExecutorShutdown threw " + e.toString());
-		}
-	}
-
-	
-	class PerTestSettings
-	{
-		PerTestSettings(String testName) { this.testName = testName; }
-		
-		public String testName;
-		public String storageContainerName;
-		public RealEventHubUtilities utils;
-		public String telltale;
-		public ArrayList<String> partitionIds;
-		public PrefabGeneralErrorHandler general;
-		public PrefabProcessorFactory factory;
-		public EventProcessorHost host;
 	}
 }

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -1,0 +1,301 @@
+package com.microsoft.azure.eventprocessorhost;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.junit.AfterClass;
+
+import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.servicebus.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.ServiceBusException;
+
+public class TestBase
+{
+	PerTestSettings testSetup(PerTestSettings settings) throws Exception
+	{
+		TestUtilities.log(settings.getTestName() + " starting\n");
+		
+		String effectiveHostName = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.HOST_OVERRIDE) ?
+				settings.inoutEPHConstructorArgs.getHostName() : settings.getTestName() + "-1";
+
+		settings.outUtils = new RealEventHubUtilities();
+		settings.outPartitionIds = settings.outUtils.setup(settings.inEntityDoesNotExist ? 8 : RealEventHubUtilities.QUERY_ENTITY_FOR_PARTITIONS);
+		ConnectionStringBuilder environmentCSB = settings.outUtils.getConnectionString();
+
+		String effectiveEntityPath = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE) ?
+				settings.inoutEPHConstructorArgs.getEHPath() : environmentCSB.getEntityPath();
+				
+		String effectiveConsumerGroup = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.CONSUMER_GROUP_OVERRIDE) ?
+				settings.inoutEPHConstructorArgs.getConsumerGroupName() : EventHubClient.DEFAULT_CONSUMER_GROUP_NAME; 
+
+		String effectiveConnectionString = environmentCSB.toString();
+		if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_PATH_REPLACE_IN_CONNECTION) ||
+				settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH))
+		{
+			ConnectionStringBuilder replacedCSB = new ConnectionStringBuilder(environmentCSB.getEndpoint(),
+					settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ? "" : settings.inoutEPHConstructorArgs.getEHPath(), 
+					environmentCSB.getSasKeyName(), environmentCSB.getSasKey());
+			replacedCSB.setOperationTimeout(environmentCSB.getOperationTimeout());
+			replacedCSB.setRetryPolicy(environmentCSB.getRetryPolicy());
+			effectiveConnectionString = replacedCSB.toString();
+		}
+		if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_OVERRIDE))
+		{
+			effectiveConnectionString = settings.inoutEPHConstructorArgs.getEHConnection();
+		}
+		
+		ExecutorService effectiveExecutor = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EXECUTOR_OVERRIDE) ?
+				settings.inoutEPHConstructorArgs.getExecutor() : null;
+		
+		settings.outTelltale = settings.getTestName() + "-telltale-" + EventProcessorHost.safeCreateUUID();
+		settings.outGeneralErrorHandler = new PrefabGeneralErrorHandler();
+		settings.outProcessorFactory = new PrefabProcessorFactory(settings.outTelltale, settings.inDoCheckpoint, true, true);
+		
+		settings.inOptions.setExceptionNotification(settings.outGeneralErrorHandler);
+		
+		if (settings.inoutEPHConstructorArgs.useExplicitManagers())
+		{
+			ICheckpointManager effectiveCheckpointMananger = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.CHECKPOINT_MANAGER_OVERRIDE) ?
+					settings.inoutEPHConstructorArgs.getCheckpointMananger() : new BogusCheckpointMananger();
+			ILeaseManager effectiveLeaseManager = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.LEASE_MANAGER_OVERRIDE) ?
+					settings.inoutEPHConstructorArgs.getLeaseManager() : new BogusLeaseManager();
+					
+			settings.outHost = new EventProcessorHost(effectiveHostName, effectiveEntityPath, effectiveConsumerGroup, effectiveConnectionString,
+					effectiveCheckpointMananger, effectiveLeaseManager, effectiveExecutor);
+		}
+		else
+		{
+			String effectiveStorageConnectionString = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.STORAGE_CONNECTION_OVERRIDE) ?
+					settings.inoutEPHConstructorArgs.getStorageConnection() : TestUtilities.getStorageConnectionString(); 
+					
+			String effectiveStorageContainerName = settings.getTestName().toLowerCase() + "-" + EventProcessorHost.safeCreateUUID();
+			if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.STORAGE_CONTAINER_OVERRIDE))
+			{
+				effectiveStorageContainerName = settings.inoutEPHConstructorArgs.getStorageContainerName();
+			}
+			else
+			{
+				settings.inoutEPHConstructorArgs.setDefaultStorageContainerName(effectiveStorageContainerName);
+			}
+			
+			String effectiveBlobPrefix = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.STORAGE_BLOB_PREFIX_OVERRIDE) ?
+					settings.inoutEPHConstructorArgs.getStorageBlobPrefix() : null;
+					
+			settings.outHost = new EventProcessorHost(effectiveHostName, effectiveEntityPath, effectiveConsumerGroup, effectiveConnectionString,
+					effectiveStorageConnectionString, effectiveStorageContainerName, effectiveBlobPrefix, effectiveExecutor);
+		}
+		
+		settings.outHost.registerEventProcessorFactory(settings.outProcessorFactory, settings.inOptions).get();
+		
+		return settings;
+	}
+	
+	void waitForTelltale(PerTestSettings settings) throws InterruptedException
+	{
+		for (int i = 0; i < 100; i++)
+		{
+			if (settings.outProcessorFactory.getAnyTelltaleFound())
+			{
+				TestUtilities.log("Telltale found\n");
+				break;
+			}
+			Thread.sleep(5000);
+		}
+	}
+	
+	void waitForTelltale(PerTestSettings settings, String partitionId) throws InterruptedException
+	{
+		for (int i = 0; i < 100; i++)
+		{
+			if (settings.outProcessorFactory.getTelltaleFound(partitionId))
+			{
+				TestUtilities.log("Telltale " + partitionId + " found\n");
+				break;
+			}
+			Thread.sleep(5000);
+		}
+	}
+
+	
+	final static int NO_CHECKS = -2; // do no checks at all, used for tests which are expected fail in startup
+	final static int ANY_NONZERO_COUNT = -1; // if expectedMessages is -1, just check for > 0
+	void testFinish(PerTestSettings settings, int expectedMessages) throws InterruptedException, ExecutionException, ServiceBusException
+	{
+		if (settings.outHost != null)
+		{
+			settings.outHost.unregisterEventProcessor();
+		}
+		
+		if (expectedMessages != NO_CHECKS)
+		{
+			TestUtilities.log("Events received: " + settings.outProcessorFactory.getEventsReceivedCount() + "\n");
+			if (expectedMessages == ANY_NONZERO_COUNT)
+			{
+				assertTrue("no messages received", settings.outProcessorFactory.getEventsReceivedCount() > 0);
+			}
+			else
+			{
+				assertEquals("wrong number of messages received", expectedMessages, settings.outProcessorFactory.getEventsReceivedCount());
+			}
+			
+			assertTrue("telltale message was not found", settings.outProcessorFactory.getAnyTelltaleFound());
+			assertEquals("partition errors seen", 0, settings.outProcessorFactory.getErrors().size());
+			assertEquals("general errors seen", 0, settings.outGeneralErrorHandler.getErrors().size());
+			for (String err : settings.outProcessorFactory.getErrors())
+			{
+				TestUtilities.log(err);
+			}
+			for (String err : settings.outGeneralErrorHandler.getErrors())
+			{
+				TestUtilities.log(err);
+			}
+		}
+		
+		settings.outUtils.shutdown();
+		
+		TestUtilities.log(settings.getTestName() + " ended");
+	}
+	
+	@AfterClass
+	public static void allTestFinish()
+	{
+		try
+		{
+			EventProcessorHost.forceExecutorShutdown(20);
+		}
+		catch (InterruptedException e)
+		{
+			TestUtilities.log("forceExecutorShutdown threw " + e.toString() + "\n");
+		}
+	}
+	
+	class BogusCheckpointMananger implements ICheckpointManager
+	{
+		@Override
+		public Future<Boolean> checkpointStoreExists()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> createCheckpointStoreIfNotExists()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> deleteCheckpointStore()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Checkpoint> getCheckpoint(String partitionId)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Checkpoint> createCheckpointIfNotExists(String partitionId)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Void> updateCheckpoint(Checkpoint checkpoint)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Void> deleteCheckpoint(String partitionId)
+		{
+			return null;
+		}
+	}
+	
+	class BogusLeaseManager implements ILeaseManager
+	{
+		@Override
+		public int getLeaseRenewIntervalInMilliseconds()
+		{
+			return 0;
+		}
+
+		@Override
+		public int getLeaseDurationInMilliseconds()
+		{
+			return 0;
+		}
+
+		@Override
+		public Future<Boolean> leaseStoreExists()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> createLeaseStoreIfNotExists()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> deleteLeaseStore()
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Lease> getLease(String partitionId)
+		{
+			return null;
+		}
+
+		@Override
+		public Iterable<Future<Lease>> getAllLeases() throws Exception
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Lease> createLeaseIfNotExists(String partitionId)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Void> deleteLease(Lease lease)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> acquireLease(Lease lease)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> renewLease(Lease lease)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> releaseLease(Lease lease)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Boolean> updateLease(Lease lease)
+		{
+			return null;
+		}
+	}
+}

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
@@ -18,6 +18,9 @@ class TestUtilities
 	
 	static final Logger TEST_LOGGER = Logger.getLogger("servicebus.test-eph.trace");
 	
+	static final String syntacticallyCorrectDummyConnectionString =
+			"Endpoint=sb://notreal.servicebus.windows.net/;SharedAccessKeyName=notreal;SharedAccessKey=NOTREALNOTREALNOTREALNOTREALNOTREALNOTREALN=;EntityPath=NOTREAL";
+	
 	static Boolean logToConsole = null;
 	
 	static void setupLogging()

--- a/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
+++ b/java/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
@@ -5,11 +5,49 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 class TestUtilities
 {
 	static String getStorageConnectionString()
 	{
 		String retval = System.getenv("EPHTESTSTORAGE");
 		return ((retval != null) ? retval : "");
+	}
+	
+	static final Logger TEST_LOGGER = Logger.getLogger("servicebus.test-eph.trace");
+	
+	static Boolean logToConsole = null;
+	
+	static void setupLogging()
+	{
+		logToConsole = (System.getenv("LOGTOCONSOLE") != null);
+	}
+	
+	static void console(String message)
+	{
+		if (logToConsole == null)
+		{
+			setupLogging();
+		}
+		if (logToConsole.booleanValue())
+		{
+			System.out.print(message);
+		}
+	}
+
+	static void log(String message)
+	{
+		console(message);
+		TEST_LOGGER.log(Level.INFO, message);
+	}
+	
+	static void logConditional(boolean doLog, String message)
+	{
+		if (doLog)
+		{
+			log(message);
+		}
 	}
 }

--- a/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/IllegalEntityException.java
+++ b/java/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/IllegalEntityException.java
@@ -22,17 +22,17 @@ public class IllegalEntityException extends ServiceBusException
 		super(false);
 	}
 
-	IllegalEntityException(final String message)
+	public IllegalEntityException(final String message)
 	{
 		super(false, message);
 	}
 
-	IllegalEntityException(final Throwable cause)
+	public IllegalEntityException(final Throwable cause)
 	{
 		super(false, cause);
 	}
 
-	IllegalEntityException(final String message, final Throwable cause)
+	public IllegalEntityException(final String message, final Throwable cause)
 	{
 		super(false, message, cause);
 	}


### PR DESCRIPTION
EventProcessorHost constructor changes: add blob prefix name, add user-supplied threadpool, implement argument validation.
Handle nonexistent event hubs and consumer groups better. Make IllegalEntityException constructors public so EPH can use it.
Deprecate PartitionContext.setOffsetAndSequenceNumber.