### PR TITLE
Fixing group id / client id mix up in quickstart consumer

### DIFF
--- a/samples/kafka/quickstart/consumer/src/main/java/com/example/app/TestConsumerThread.java
+++ b/samples/kafka/quickstart/consumer/src/main/java/com/example/app/TestConsumerThread.java
@@ -41,7 +41,7 @@ public class TestConsumerThread implements Runnable {
         try {
             final Properties properties = new Properties();
             synchronized (TestConsumerThread.class) {
-                properties.put(ConsumerConfig.GROUP_ID_CONFIG, "KafkaExampleConsumer#" + id);
+                properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "KafkaExampleConsumer#" + id);
                 id++;
             }
             properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());

--- a/samples/kafka/quickstart/consumer/src/main/resources/consumer.config
+++ b/samples/kafka/quickstart/consumer/src/main/resources/consumer.config
@@ -1,5 +1,6 @@
 bootstrap.servers={YOUR.EVENTHUBS.FQDN}:9093
 group.id=$Default
+request.timeout.ms=60000
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{YOUR.EVENTHUBS.CONNECTION.STRING}";

--- a/samples/kafka/quickstart/consumer/src/main/resources/consumer.config
+++ b/samples/kafka/quickstart/consumer/src/main/resources/consumer.config
@@ -1,4 +1,5 @@
 bootstrap.servers={YOUR.EVENTHUBS.FQDN}:9093
+group.id=$Default
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{YOUR.EVENTHUBS.CONNECTION.STRING}";


### PR DESCRIPTION
Accidentally set the group id per thread instead of the client id in quickstart's TestConsumerThread.java::createConsumer()