### PR TITLE
Fix java compile errors

### DIFF
--- a/samples/Java/Basic/AdvancedSendOptions/pom.xml
+++ b/samples/Java/Basic/AdvancedSendOptions/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
-    <groupId>simplesend</groupId>
+    <groupId>advancedsendoptions</groupId>
     <version>1.0.0</version>
-    <artifactId>simplesend</artifactId>
+    <artifactId>advancedsendoptions</artifactId>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/Java/Benchmarks/AutoScaleOnIngress/src/main/java/com/microsoft/azure/eventhubs/samples/autoscaleoningress/EventHubClientPool.java
+++ b/samples/Java/Benchmarks/AutoScaleOnIngress/src/main/java/com/microsoft/azure/eventhubs/samples/autoscaleoningress/EventHubClientPool.java
@@ -7,9 +7,9 @@ package com.microsoft.azure.eventhubs.samples.autoscaleoningress;
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.EventHubException;
-
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 
@@ -19,20 +19,22 @@ public final class EventHubClientPool {
     private final String connectionString;
     private final Object previouslySentLock = new Object();
     private final EventHubClient[] clients;
+    private final ExecutorService executorService;
 
     private int previouslySent = 0;
 
-    EventHubClientPool(final int poolSize, final String connectionString) {
+    EventHubClientPool(final int poolSize, final String connectionString, ExecutorService executorService) {
         this.poolSize = poolSize;
         this.connectionString = connectionString;
         this.clients = new EventHubClient[this.poolSize];
+        this.executorService = executorService;
     }
 
     public CompletableFuture<Void> initialize() throws IOException, EventHubException {
         final CompletableFuture[] createSenders = new CompletableFuture[this.poolSize];
         for (int count = 0; count < poolSize; count++) {
             final int clientsIndex = count;
-            createSenders[count] = EventHubClient.createFromConnectionString(this.connectionString).thenAccept(new Consumer<EventHubClient>() {
+            createSenders[count] = EventHubClient.create(this.connectionString, executorService).thenAccept(new Consumer<EventHubClient>() {
                 @Override
                 public void accept(EventHubClient eventHubClient) {
                     clients[clientsIndex] = eventHubClient;


### PR DESCRIPTION
There are compile errors in the java examples:

1) the artifact+groupId of the advancedsendoptions was set to "simplesend" (i guess copy pasta error). this breaks the maven build as submodule names are unique.
2) code of some examples has not been updated when the dependency for azure-eventhubs was upgraded from 0.15.1 to >1.0.0. This version bump includes breaking API changes, hence it doesn't compile anymore.

This PR addresses these issues.