### PR TITLE
Clean up of the EventHubsCaptureEventGridDemo sample in the azure-event-hubs repo

### DIFF
--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
@@ -35,11 +35,17 @@
     <Reference Include="Avro, Version=0.9.0.0, Culture=neutral, PublicKeyToken=b1248d7eeb9d0814, processorArchitecture=MSIL">
       <HintPath>..\packages\Apache.Avro.1.7.7.2\lib\Avro.dll</HintPath>
     </Reference>
+    <Reference Include="Azure.Core">
+      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.core\1.8.1\lib\netstandard2.0\Azure.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Azure.Storage.Blobs">
+      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.storage.blobs\12.8.1\lib\netstandard2.0\Azure.Storage.Blobs.dll</HintPath>
+    </Reference>
+    <Reference Include="Azure.Storage.Common">
+      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.storage.common\12.7.1\lib\netstandard2.0\Azure.Storage.Common.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -49,9 +55,6 @@
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.3.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
@@ -35,15 +35,6 @@
     <Reference Include="Avro, Version=0.9.0.0, Culture=neutral, PublicKeyToken=b1248d7eeb9d0814, processorArchitecture=MSIL">
       <HintPath>..\packages\Apache.Avro.1.7.7.2\lib\Avro.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Core">
-      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.core\1.8.1\lib\netstandard2.0\Azure.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Azure.Storage.Blobs">
-      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.storage.blobs\12.8.1\lib\netstandard2.0\Azure.Storage.Blobs.dll</HintPath>
-    </Reference>
-    <Reference Include="Azure.Storage.Common">
-      <HintPath>C:\Users\v-wenjyu\.nuget\packages\azure.storage.common\12.7.1\lib\netstandard2.0\Azure.Storage.Common.dll</HintPath>
-    </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
     </Reference>
@@ -71,6 +62,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+	  <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/DWDumper.csproj
@@ -35,6 +35,10 @@
     <Reference Include="Avro, Version=0.9.0.0, Culture=neutral, PublicKeyToken=b1248d7eeb9d0814, processorArchitecture=MSIL">
       <HintPath>..\packages\Apache.Avro.1.7.7.2\lib\Avro.dll</HintPath>
     </Reference>
+    <Reference Include="Azure.Storage.Blobs, Version=12.8.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Azure.Storage.Blobs.12.8.1\lib\netstandard2.0\Azure.Storage.Blobs.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
     </Reference>
@@ -62,7 +66,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-	  <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/Program.cs
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/Program.cs
@@ -32,14 +32,9 @@ namespace DWDumper
 
         public void Dump()
         {
-            // Get the blob reference
-            string connectionString = "ConnectionString";
-            string containerName = "containerName";
-            string blobName = "blobName";
+            // Get the blob reference           
 
-            BlobContainerClient container = new BlobContainerClient(connectionString, containerName);
-            container.Create();
-            BlobClient blob = container.GetBlobClient(blobName);
+            BlobClient blob = new BlobClient(new Uri(EventHubsCaptureAvroBlobUri));
 
             using (var dataTable = GetWindTurbineMetricsTable())
             {

--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/Program.cs
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/Program.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Avro.File;
 using Avro.Generic;
 using Newtonsoft.Json;
-using Microsoft.WindowsAzure.Storage;
+using Azure.Storage.Blobs;
 
 namespace DWDumper
 {
@@ -33,9 +33,13 @@ namespace DWDumper
         public void Dump()
         {
             // Get the blob reference
-            var storageAccount = CloudStorageAccount.Parse(StorageConnectionString);
-            var blobClient = storageAccount.CreateCloudBlobClient();
-            var blob = blobClient.GetBlobReferenceFromServer(new Uri(EventHubsCaptureAvroBlobUri));
+            string connectionString = "ConnectionString";
+            string containerName = "containerName";
+            string blobName = "blobName";
+
+            BlobContainerClient container = new BlobContainerClient(connectionString, containerName);
+            container.Create();
+            BlobClient blob = container.GetBlobClient(blobName);
 
             using (var dataTable = GetWindTurbineMetricsTable())
             {

--- a/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/packages.config
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/DWDumper/packages.config
@@ -12,5 +12,5 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net461" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net461" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="8.3.0" targetFramework="net461" />
+  <package id="Azure.Storage.Blobs" version="12.8.1" targetFramework="net461" />
 </packages>

--- a/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/Function1.cs
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/Function1.cs
@@ -17,7 +17,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.EventGrid;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host;
-using Microsoft.WindowsAzure.Storage;
+using Azure.Storage.Blobs;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -66,14 +66,18 @@ namespace FunctionEGDWDumper
         private static async void Dump(Uri fileUri)
         {
             // Get the blob reference
-            var storageAccount = CloudStorageAccount.Parse(StorageConnectionString);
-            var blobClient = storageAccount.CreateCloudBlobClient();
-            var blob = await blobClient.GetBlobReferenceFromServerAsync(fileUri);
+            string connectionString = "ConnectionString";
+            string containerName = "containerName";
+            string blobName = "blobName";
+
+            BlobContainerClient container = new BlobContainerClient(connectionString, containerName);
+            container.Create();
+            BlobClient blob = container.GetBlobClient(blobName);
 
             using (var dataTable = GetWindTurbineMetricsTable())
             {
                 // Parse the Avro File
-                Stream blobStream = await blob.OpenReadAsync(null, null, null);
+                Stream blobStream = await blob.OpenReadAsync(null);
                 using (var avroReader = DataFileReader<GenericRecord>.OpenReader(blobStream))
                 {
                     while (avroReader.HasNext())

--- a/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/Function1.cs
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/Function1.cs
@@ -66,13 +66,7 @@ namespace FunctionEGDWDumper
         private static async void Dump(Uri fileUri)
         {
             // Get the blob reference
-            string connectionString = "ConnectionString";
-            string containerName = "containerName";
-            string blobName = "blobName";
-
-            BlobContainerClient container = new BlobContainerClient(connectionString, containerName);
-            container.Create();
-            BlobClient blob = container.GetBlobClient(blobName);
+            BlobClient blob = new BlobClient(fileUri);
 
             using (var dataTable = GetWindTurbineMetricsTable())
             {

--- a/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/FunctionEGDWDumper.csproj
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/FunctionEGDWDumper.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.9.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.2.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />

--- a/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/WindTurbineDataGenerator.csproj
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/WindTurbineDataGenerator.csproj
@@ -41,9 +41,6 @@
     <Reference Include="Microsoft.Azure.Amqp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Amqp.2.4.5\lib\net45\Microsoft.Azure.Amqp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.EventHubs, Version=1.0.2.0, Culture=neutral, PublicKeyToken=7e34167dcc6d6d8c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.EventHubs.1.0.2\lib\net451\Microsoft.Azure.EventHubs.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>

--- a/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/packages.config
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/packages.config
@@ -3,7 +3,6 @@
   <package id="Azure.Core" version="1.5.0" targetFramework="net461" />
   <package id="Azure.Messaging.EventHubs" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Amqp" version="2.4.5" targetFramework="net461" />
-  <package id="Microsoft.Azure.EventHubs" version="1.0.2" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net461" />

--- a/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/packages.config
+++ b/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Azure.Core" version="1.5.0" targetFramework="net461" />
-  <package id="Azure.Messaging.EventHubs" version="5.2.0" targetFramework="net461" />
+  <package id="Azure.Messaging.EventHubs" version="5.4.0" targetFramework="net461" />
   <package id="Microsoft.Azure.Amqp" version="2.4.5" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />


### PR DESCRIPTION
- The WindTurbineDataGenerator project does not use the old EH package anymore, but it does list it in the [packages.config file](https://github.com/Azure/azure-event-hubs/blob/e9e01dd7b5bb4a32835f5ece855b9d18c579e828/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/packages.config#L6) and the [csproj file](https://github.com/Azure/azure-event-hubs/blob/e9e01dd7b5bb4a32835f5ece855b9d18c579e828/samples/e2e/EventHubsCaptureEventGridDemo/WindTurbineDataGenerator/WindTurbineDataGenerator.csproj#L44)
- The FunctionEGDWDumper project lists Azure.Storage.Blobs (the new Storage package) in the [csproj file](https://github.com/Azure/azure-event-hubs/blob/5a16c140921d263b22828fe8b19127f6779465b5/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/FunctionEGDWDumper.csproj#L9), but uses the older Microsoft.WindowsAzure.Storage package in the [Function.1.cs file](https://github.com/Azure/azure-event-hubs/blob/5a16c140921d263b22828fe8b19127f6779465b5/samples/e2e/EventHubsCaptureEventGridDemo/FunctionEGDWDumper/Function1.cs#L20)
- The DWDumper project lists the older Key Vault package in the csproj file, but does not use it anywhere in code
- The DWDumper project also uses the older Storage package. It should use Azure.Storage.Blobs instead

l have updated these file, and use new package Azure.Storage.Blobs in DWDumper project.

@ramya-rao-a , @jongio for notification.